### PR TITLE
Fix init db job

### DIFF
--- a/deployment/entity-service/templates/init-db-job.yaml
+++ b/deployment/entity-service/templates/init-db-job.yaml
@@ -2,37 +2,47 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: entityservice-init-db
+  labels:
+    # The "heritage" label is used to track which tool deployed a given chart.
+    # It is useful for admins who want to see what releases a particular tool
+    # is responsible for.
+    heritage: {{ .Release.Service }}
+    # The "release" convention makes it easy to tie a release to all of the
+    # Kubernetes resources that were created as part of that release.
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "fullname" . }}
+    tier: aux
+  annotations:
+    # This job only gets executed on install, not after an upgrade.
+    # Manual intervention (or a job with a post-upgrade hook) is required to migrate a
+    # production database.
+    "helm.sh/hook": post-install
 spec:
   template:
     metadata:
+      name: {{ template "fullname" . }}
       labels:
+        release: {{ .Release.Name }}
         app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        tier: aux
-      annotations:
-        # This job only gets executed on install, not after an upgrade.
-        # Manual intervention (or a job with a post-upgrade hook) is required to migrate a
-        # production database.
-        "helm.sh/hook": post-install
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: db-init
-        image: {{ .Values.api.imageRegistery }}/{{ .Values.api.app.image }}:{{ .Values.api.app.tag }}
-        env:
-          - name: DATABASE_SERVER
-            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "fullname" . }}
-                key: postgresPassword
-          - name: DEBUG
-            value: {{default "false" .Values.api.app.debug | quote }}
-          - name: FLASK_APP
-            value: entityservice.py
-        command:
-          - "flask"
-          - "initdb"
-      imagePullSecrets:
-        - name: {{ template "name" . }}-pull-secret
+    restartPolicy: Never
+    containers:
+    - name: db-init
+      image: {{ .Values.api.imageRegistery }}/{{ .Values.api.app.image }}:{{ .Values.api.app.tag }}
+      env:
+        - name: DATABASE_SERVER
+          value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: postgresPassword
+        - name: DEBUG
+          value: {{default "false" .Values.api.app.debug | quote }}
+        - name: FLASK_APP
+          value: entityservice.py
+      command:
+        - "flask"
+        - "initdb"
+    imagePullSecrets:
+      - name: {{ template "name" . }}-pull-secret

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -29,14 +29,14 @@ api:
 
   www:
     image: "entity-nginx"
-    tag: "v1.3.1"
+    tag: "v1.3.2"
     memory: 256Mi
     cpu: 200m
     containerPort: 8851
   app:
     image: "entity-app"
     memory: 1Gi
-    tag: "v1.7.0"
+    tag: "v1.7.1"
     debug: "false"
     containerPort: 8000
   Replicas: 1
@@ -44,7 +44,7 @@ api:
 workers:
   imageRegistery: "quay.io/n1analytics"
   image: "entity-app"
-  tag: "v1.7.0"
+  tag: "v1.7.1"
   replicas: 1
   debug: "false"
 


### PR DESCRIPTION
I found I couldn't use `helm upgrade release` because of an issue with the init db job. I've refactored the job from the current helm docs (which involved more changes than I expected).