### PR TITLE
Experimental certificate template

### DIFF
--- a/deployment/entity-service/templates/certificate.yaml
+++ b/deployment/entity-service/templates/certificate.yaml
@@ -2,18 +2,27 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: {{ .Values.api.certManager.certName }}
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: "{{ .Release.Service }}"
 spec:
   secretName: {{ .Values.api.certManager.secretName }}
   issuerRef:
-    name: {{ .Values.api.certManager.issuer }}
+{{ toYaml .Values.api.certManager.issuerRef | indent 4 }}
   commonName: {{ .Values.api.certManager.commonName }}
-  dnsNames:
-  - {{ .Values.api.certManager.commonName }}
   acme:
     config:
     - http01:
         ingressClass: nginx
       domains:
-      - {{ .Values.api.certManager.commonName }}
+      {{- range .Values.api.ingress.hosts }}
+      - {{ . }}
+      {{- end }}
+  dnsNames:
+  {{- range .Values.api.ingress.hosts }}
+  - {{ . }}
+  {{- end -}}
 {{- end -}}

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -90,22 +90,27 @@ api:
     ## Must be provided if Ingress is enabled
     hosts:
      - beta.entityservice.edn.io
+     - www.beta.entityservice.edn.io
 
     ## Entity Service API Ingress TLS configuration
     ## This example setup is for nginx-ingress. We use certificate manager.
     ## to create the TLS secret in the namespace with the name
     ## below.
-    tls: []
-     #- secretName: es-tls
-     #  hosts:
-     #    - beta.entityservice.edn.io
+    tls: #[]
+    - secretName: es-tls
+      hosts:
+      - beta.entityservice.edn.io
+      - www.beta.entityservice.edn.io
 
-  # Configure a cert-manager (caution experimental!)
+  # Configure a cert-manager Certificate (caution experimental!)
   certManager:
     enabled: true
-    issuer: letsencrypt
-    secretName: entity-service-tls
-    certName: entity-service-tls
+    secretName: es-tls
+    issuerRef:
+      #name: letsencrypt
+      name: letsencrypt-cluster-issuer
+      kind: ClusterIssuer
+    # Must be in api.ingress.hosts
     commonName: beta.entityservice.edn.io
 
   service:


### PR DESCRIPTION
This introduces optional configuration for cert-manager to the helm deployment scripts.

See https://github.com/n1analytics/n1-dev-tools/issues/88

