### PR TITLE
Update Jenkins to build docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,21 @@
+# Usage
+# # docker run -it -v <PATH TO DOCS>:/docs -v <OUTPUT HTML PATH>:/build quay.io/n1analytics/entity-app:doc-builder
+FROM quay.io/n1analytics/entity-app:latest
+
+MAINTAINER "Brian Thorne <brian.thorne@data61.csiro.au>"
+USER root
+RUN apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+	pandoc dvipng texlive-extra-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+ADD doc-requirements.txt /src/requirements.txt
+
+WORKDIR /src
+RUN pip install -U -r requirements.txt
+USER user
+
+# Note we expect the user to mount the sources to build...
+#ADD . /src
+
+CMD python -m sphinx /src /build

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -7,3 +7,4 @@ export APPVERSION=$(cat backend/VERSION)
 
 docker build -t quay.io/n1analytics/entity-app:latest backend
 docker build -t quay.io/n1analytics/entity-nginx:latest frontend
+docker build -t quay.io/n1analytics/entity-app:doc-builder docs

--- a/tools/make-release.sh
+++ b/tools/make-release.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# This creates a source release
+
 set -e
 cd $(dirname "$0")
 export APPVERSION=$(cat ../backend/VERSION)
@@ -13,10 +16,12 @@ rm -fr /tmp/n1-es/*.iml
 rm -fr /tmp/n1-es/.ipynb*
 rm -fr /tmp/n1-es/docs/*
 
-sphinx-build -b html ../docs /tmp/n1-es/docs
+# Release should include docs. Current approach is to build them in a top level directory before
+# running make-release.sh - e.g. using:
+#docker run -v `pwd`/../docs:/src -v /tmp/n1-es/docs:/build quay.io/n1analytics/entity-app:doc-builder
 
 cd /tmp/n1-es
 find . | grep -E "(__pycache__|\.pyc)" | xargs rm -fr
 
-zip -r /tmp/n1-es-$APPVERSION.zip .
-tar cf /tmp/n1-es-$APPVERSION.tar.lzma --lzma .
+zip -q -r /tmp/n1-es-$APPVERSION.zip .
+

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -28,6 +28,7 @@ docker tag quay.io/n1analytics/entity-nginx:latest quay.io/n1analytics/entity-ng
 
 echo "Pushing images to quay.io";
 docker push quay.io/n1analytics/entity-app:${ENTITY_APP_LABEL};
+docker push quay.io/n1analytics/entity-app:doc-builder;
 docker push quay.io/n1analytics/entity-nginx:${ENTITY_NGINX_LABEL};
 
 echo "Images uploaded";


### PR DESCRIPTION
Add another docker image for building docs. Jenkins now builds the doc building image then uses it to build the sphinx docs.
