### PR TITLE
Expose number of parties that have contributed data

### DIFF
--- a/docs/_static/swagger.yaml
+++ b/docs/_static/swagger.yaml
@@ -122,8 +122,8 @@ paths:
                 number_mappings: 3118
                 rate: 1793757
         '500':
-          description: | 
-            System is experiencing difficulties. 
+          description: |
+            System is experiencing difficulties.
             E.g. application can't connect to database.
   /version:
     get:
@@ -171,17 +171,17 @@ paths:
         interaction with this project.
 
         ### Schema
-        
+
         Although these comprise the column names, the raw data will never be
-        sent to this entity service. 
+        sent to this entity service.
 
         Each participant will be able to see the schema to verify it is
-        what they expect. Schema details should have been determined and agreed 
+        what they expect. Schema details should have been determined and agreed
         on by each party before starting a mapping task. This is documented
         in [schema](./concepts.html#schema).
-        
+
         ### Result Type
-        
+
         The result type specifies what information is available after the entity
         resolving process has completed. All project **runs** will use this result type.
 
@@ -579,128 +579,6 @@ paths:
         '503':
           $ref: '#/responses/RateLimited'
 
-  '/projects/{project_id}/runs/{run_id}/result':
-    get:
-      summary: Run result
-      tags:
-        - Run
-      description: |
-
-        ## Response
-
-        The response schema depends on the mapping's `result_type`. OpenAPI doesn't
-        allow different schemas (in v2) so these are documented here:
-
-        Note if the result isn't ready, a `404` will be returned.
-
-
-        ### result_type = "mapping"
-
-        The mapping of indices between parties. Data is returned as `json` object e.g,
-
-            {
-                "mapping":
-                    {
-                        "0": "5",
-                        "2": "0"
-                    }
-            }
-
-
-        ### result_type = "similarity_scores"
-
-        The list of the indices of potential matches and their similarity score
-        where the similarity score is greater than the mapping threshold.
-        Data is returned as `json` object e.g.,
-
-            {
-                "similarity_scores":
-                    [
-                        [5, 27, 1.0],
-                        [14, 10, 1.0]
-                    ]
-            }
-
-
-        The element in the list is of the following format `[indexA, indexB, score]`,
-        where `indexA` refers to the index of entity from data provider 1, `indexB` is the index of entity
-        from data provider 2 that is a potential match to entity in `indexA`, and `score` is the similarity score
-        representing the likelihood that entity in `indexA` and entity in `indexB` is a match.
-
-        `indexA` and `indexB` starts from 0.
-
-        The value of `score` is between 0.0 and 1.0, where 0.0 corresponds to no match
-        and 1.0 corresponds to total match.
-
-        ### result_type = "permutation"
-
-        The permutation, and mask specific for the calling organisation.
-        Data is returned as `json` object e.g,
-
-
-            {
-                "permutation": [3,0,4,1,2],
-                "mask": [0,1,0,1,1],   <-- As paillier encrypted, base64 encoded numbers
-                "paillier_context": {
-                    "base": 2,
-                    "encoded": true
-                }
-            }
-
-
-        In this example the first three elements in the original dataset are included,
-        but have been reordered to the second, fourth and fifth positions. The other elements
-        have been excluded with the encrypted mask. Note the permutation is specific to
-        the caller. Also any data after row 5 is to be discarded after the reordering has
-        been applied.
-
-        The `mask` is a json array of Paillier encrypted numbers. These are the ciphertexts
-        as integer strings. The encoded number base is `2`, and the precision is set to
-        `1e3`. The exponent is not serialized, as it will always be 0. The resulting ciphertext
-        is serialized with base64 encoding.
-
-        In Python using `python-paillier`: `int_to_base64(public_key.encrypt(enc, precision).ciphertext())`
-
-
-        ### result_type = "permutation_unencrypted_mask"
-
-        The data providers will receive the permutation:
-
-
-            {
-                "permutation": [3,0,4,1,2],
-                "rows": 5
-            }
-
-
-        The creator of the mapping gets access to the mask:
-
-            {
-                "mask": [0,1,0,1,1]
-            }
-
-
-        The mask is an array of 0/1 numbers.
-      parameters:
-        - $ref: '#/parameters/project_id'
-        - $ref: '#/parameters/run_id'
-        - $ref: '#/parameters/token'
-      responses:
-        '200':
-          description: Successful response
-        400:
-          $ref: '#/responses/BadRequest'
-        401:
-          $ref: '#/responses/Unauthorized'
-        403:
-          $ref: '#/responses/Unauthorized'
-        404:
-          $ref: '#/responses/NotFound'
-        '500':
-          $ref: '#/responses/Error'
-        '503':
-          $ref: '#/responses/RateLimited'
-
 parameters:
   token:
     required: true
@@ -893,7 +771,7 @@ definitions:
 
       public_key:
         $ref: "#/definitions/PaillierPublicKey"
-        
+
       paillier_context:
         $ref: "#/definitions/PaillierContext"
 
@@ -999,7 +877,7 @@ definitions:
       type: string
       format: byte
       description: Base64 encoded CLK data
-      
+
   UploadReceipt:
     properties:
       receipt_token:


### PR DESCRIPTION
Tiny addition to `ProjectDescription` to expose how many data providers have uploaded their CLKs.