### PR TITLE
Minor openapi update

### DIFF
--- a/docs/_static/swagger.yaml
+++ b/docs/_static/swagger.yaml
@@ -811,13 +811,11 @@ definitions:
         format: double
         description: |
           The similarity threshold (a number between 0 and 1) above which two entites will be considered a match.
-      k:
-        type: number
+      notes:
+        type: string
         description: |
-          The top k edges per entity (above the threshold) will be included in the similarity score result.
-          Note the entity solver for output type `mapping` will only take the top match.
+          Some optional text that we store along with the run.
 
-          Optional: all results will be returned by default.
     required:
       - threshold
 


### PR DESCRIPTION
We were exposing the `k` value but not really using it and it has issues in a distributed setting so I've removed that.

We were not exposing `notes` so now we do.

We were returning 200 when creating resources so now we return 201