### PR TITLE
Fix name of test log container

### DIFF
--- a/docs/local-deployment.rst
+++ b/docs/local-deployment.rst
@@ -73,7 +73,7 @@ this can be added in to run along with the rest of the service::
 
     docker-compose -p n1estest -f tools/docker-compose.yml -f tools/ci.yml  up -d
 
-    docker logs -f n1estest_ci_1
+    docker logs -f n1estest_tests_1
 
     docker-compose -p n1estest -f tools/docker-compose.yml -f tools/ci.yml down
 


### PR DESCRIPTION
It seems that the docs were overlooked in 8c20c48da0874390fa4823b7505546be1eb232ba.