### PR TITLE
return the dataprovider ids in order

### DIFF
--- a/backend/entityservice/database/selections.py
+++ b/backend/entityservice/database/selections.py
@@ -137,6 +137,7 @@ def get_project_dataset_sizes(db, project_id):
         WHERE
           bloomingdata.dp=dataproviders.id AND
           dataproviders.project=%s
+        ORDER BY dataproviders.id
         """
     query_result = query_db(db, sql_query, [project_id], one=False)
     return [r['size'] for r in query_result]


### PR DESCRIPTION
the order of the dataprovider ids is important, as they state the order of the dataprovider in the project. The order of dataprovider ids and tokens have to align, otherwise the result will be swapped. 

Fixes #190

