### PR TITLE
Adjusting deployment to work with latest redis chart.

### DIFF
--- a/deployment/entity-service/templates/NOTES.txt
+++ b/deployment/entity-service/templates/NOTES.txt
@@ -1,13 +1,13 @@
 
-*- N1 Analytics Entity Service -*
+*- Confidential Computing Anonlink Service Deployed -*
 
-Soon you should be able to visit the entity service.
+Soon you should be able to visit the entity service api.
 
 1. Get the entity service URL by running:
 
 {{- if contains "NodePort" .Values.api.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "es.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 
@@ -29,7 +29,7 @@ add the DNS entry for {{ .Values.api.ingress.hosts }} now.
 Alternatively you can forward the port of the entity service's nginx server to your
 local machine:
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "es.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl port-forward $POD_NAME 8080:80
 
 And visit http://127.0.0.1:8080/

--- a/deployment/entity-service/templates/_helpers.tpl
+++ b/deployment/entity-service/templates/_helpers.tpl
@@ -28,7 +28,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 We define the release labels that will be applied to all deployments.
 */}}
 {{- define "es.release_labels" }}
-app: {{ template "fullname" . }}
+app: {{ template "es.fullname" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 # The "heritage" label is used to track which tool deployed a given chart.
 # It is useful for admins who want to see what releases a particular tool

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "es.release_labels" . | indent 4 }}
 data:
-  REDIS_SERVER: "{{ .Release.Name }}-{{ .Values.redis.nameOverride }}"
+  REDIS_SERVER: "{{ .Release.Name }}-{{ .Values.redis.nameOverride }}-master"
   DATABASE_SERVER: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
   DEBUG: {{ .Values.workers.debug | quote }}
   ENTITY_MATCH_THRESHOLD: {{ .Values.workers.MATCH_THRESHOLD | quote }}

--- a/deployment/entity-service/templates/es-credentials.yaml
+++ b/deployment/entity-service/templates/es-credentials.yaml
@@ -6,6 +6,6 @@ metadata:
     {{- include "es.release_labels" . | indent 4 }}
 data:
   postgresPassword: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
-  redisPassword: {{ .Values.redis.redisPassword | b64enc | quote }}
+  redisPassword: {{ .Values.redis.password | b64enc | quote }}
   minioAccessKey: {{ .Values.minio.accessKey | b64enc | quote }}
   minioSecretKey: {{ .Values.minio.secretKey | b64enc | quote }}

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -56,10 +56,10 @@ api:
     resources:
       limits:
         cpu: 1
-        memory: 1Gi
+        memory: 8Gi
       requests:
         cpu: 500m
-        memory: 1Gi
+        memory: 512Mi
 
     debug: "false"
 
@@ -214,20 +214,40 @@ postgresql:
 
 redis:
   # https://github.com/kubernetes/charts/tree/master/stable/redis#configuration
-  redisPassword: "gOgRockEPtiN"
-  persistence:
+  cluster:
     enabled: true
-    storageClass: "default"
-    size: "10Gi"
+    slaveCount: 1
+  usePassword: true
+  password: "YGcBZ65tsg56"
   metrics:
     enabled: true
-  resources:
-    requests:
-      #memory: 8Gi
-      cpu: 200m
-    limits:
-      #memory: 20Gi
-      cpu: 300m
+
+  master:
+    persistence:
+      enabled: true
+      storageClass: "default"
+      size: "10Gi"
+
+    service:
+      type: ClusterIP
+
+    resources:
+      requests:
+        #memory: 2Gi
+        cpu: 200m
+      limits:
+        #memory: 20Gi
+        cpu: 300m
+
+  slave:
+    resources:
+      requests:
+        #memory: 2Gi
+        cpu: 200m
+      limits:
+        #memory: 20Gi
+        cpu: 300m
+
   nameOverride: "redis"
 
 minio:


### PR DESCRIPTION
Also fix a merge error with "fullname" in template. Apparently helm variables should be scoped.

Trying - with some success - to deploy to GCE: http://es.gce.data61.xyz/api/v1/status

