### PR TITLE
Abstract out the calculation of how long to wait for matching

### DIFF
--- a/backend/entityservice/tests/test_project_run_results.py
+++ b/backend/entityservice/tests/test_project_run_results.py
@@ -1,11 +1,11 @@
 import pytest
 
-from entityservice.tests.config import url
-from entityservice.tests.util import create_project_upload_fake_data, create_project_no_data, post_run, get_run_result
+from entityservice.tests.util import create_project_no_data, post_run, get_run_result, wait_approx_run_time
 
 
 def test_run_mapping_results(requests, mapping_project):
     run_id = post_run(requests, mapping_project, 0.95)
+    wait_approx_run_time(mapping_project['size'])
     result = get_run_result(requests, mapping_project, run_id)
     assert 'mapping' in result
     assert isinstance(result['mapping'], dict)
@@ -41,4 +41,4 @@ def test_run_permutation_unencrypted_results(requests, permutations_project, thr
 def test_run_mapping_results_no_data(requests):
     empty_project = create_project_no_data(requests)
     run_id = post_run(requests, empty_project, 0.95)
-    result = get_run_result(requests, empty_project, run_id, expected_status = 404, wait=False)
+    get_run_result(requests, empty_project, run_id, expected_status = 404, wait=False)

--- a/backend/entityservice/tests/test_project_run_status.py
+++ b/backend/entityservice/tests/test_project_run_status.py
@@ -8,7 +8,6 @@ from entityservice.tests.util import has_progressed, post_run, get_run_status, w
 
 
 def test_run_status_with_clks(requests, mapping_project):
-    run_id = post_run(requests, mapping_project, 0.9)
     size = mapping_project['size']
     ensure_run_progressing(requests, mapping_project, size)
 


### PR DESCRIPTION
During testing we estimate how long it should take to compute the similarity scores, ideally this will lead to less random failures on different CI systems.