### PR TITLE
Skip starting a comparison task if the db state is already 'running'

### DIFF
--- a/backend/entityservice/async_worker.py
+++ b/backend/entityservice/async_worker.py
@@ -206,6 +206,9 @@ def compute_run(project_id, run_id):
         if res['state'] in {'completed', 'error'}:
             log.info("Run is already finished. Skipping")
             return
+        if res['state'] == 'running':
+            log.info("Run already started. Skipping")
+            return
 
         log.debug("Setting run as in progress")
         update_run_set_started(conn, run_id)

--- a/backend/entityservice/test_service.py
+++ b/backend/entityservice/test_service.py
@@ -17,7 +17,7 @@ from clkhash.bloomfilter import calculate_bloom_filters
 from clkhash.key_derivation import generate_key_lists
 from clkhash.schema import get_schema_types
 
-from phe import paillier, util
+
 from serialization import *
 from tests.util import serialize_bitarray, serialize_filters, logger, initial_delay, rate_limit_delay
 
@@ -778,6 +778,7 @@ class Timer:
     def __exit__(self, *args):
         self.end = time.clock()
         self.interval = self.end - self.start
+
 
 if __name__ == "__main__":
     size = int(os.environ.get("ENTITY_SERVICE_TEST_SIZE", "1000"))


### PR DESCRIPTION
I think I found another way we can make 2 tasks when we only want one. See #249 