### PR TITLE
 Generalise worker to many parties

### DIFF
--- a/backend/entityservice/tasks/comparing.py
+++ b/backend/entityservice/tasks/comparing.py
@@ -251,7 +251,7 @@ def _insert_similarity_into_db(db, log, run_id, merged_filename):
     autoretry_for=(minio.ResponseError,),
     retry_backoff=True,
     args_as_tags=('project_id', 'run_id'))
-def aggregate_comparisons(similarity_result_files, project_id, run_id, parent_span=None):#############
+def aggregate_comparisons(similarity_result_files, project_id, run_id, parent_span=None):
     log = logger.bind(pid=project_id, run_id=run_id)
     if similarity_result_files is None:
         raise TypeError("Inappropriate argument type - missing results files.")

--- a/backend/entityservice/tasks/comparing.py
+++ b/backend/entityservice/tasks/comparing.py
@@ -72,11 +72,10 @@ def create_comparison_jobs(project_id, run_id, parent_span=None):
 
     # Save filenames with chunk information.
     for chunk_info in chunk_infos:
-        chunk_dp1_info, chunk_dp2_info = chunk_info
-        chunk_dp1_info['storeFilename'] \
-            = filters_object_filenames[chunk_dp1_info['datasetIndex']]
-        chunk_dp2_info['storeFilename'] \
-            = filters_object_filenames[chunk_dp2_info['datasetIndex']]
+        for chunk_dp_info in chunk_info:
+            chunk_dp_index = chunk_dp_info['datasetIndex']
+            chunk_dp_store_filename = filters_object_filenames[chunk_dp_index]
+            chunk_dp_info['storeFilename'] = chunk_dp_store_filename
 
     log.info(f"Chunking into {len(chunk_infos)} computation tasks")
     current_span.log_kv({"event": "chunking", 'num_chunks': len(chunk_infos)})

--- a/backend/entityservice/tasks/permutation.py
+++ b/backend/entityservice/tasks/permutation.py
@@ -46,12 +46,13 @@ def save_and_permute(similarity_result, project_id, run_id, parent_span):
 
     if result_type == "permutations":
         log.debug("Submitting job to permute mapping")
+        dataset0_size, dataset1_size = similarity_result['datasetSizes']
         permute_mapping_data.apply_async(
             (
                 project_id,
                 run_id,
-                similarity_result['lenf1'],
-                similarity_result['lenf2'],
+                dataset0_size,
+                dataset1_size,
                 save_and_permute.get_serialized_span()
             )
         )

--- a/backend/entityservice/tasks/run.py
+++ b/backend/entityservice/tasks/run.py
@@ -39,9 +39,6 @@ def prerun_check(project_id, run_id, parent_span=None):
         log.debug("Getting dp ids for compute similarity task")
         dp_ids = get_dataprovider_ids(conn, project_id)
         log.debug("Data providers: {}".format(dp_ids))
-        if len(dp_ids) != 2:
-            log.warning(f"Only support two party comparisons at the moment. Got {len(dp_ids)}")
-            return
 
     create_comparison_jobs.delay(project_id, run_id, prerun_check.get_serialized_span())
     log.info("CLK similarity computation scheduled")

--- a/backend/entityservice/tasks/solver.py
+++ b/backend/entityservice/tasks/solver.py
@@ -9,10 +9,11 @@ from entityservice.utils import similarity_matrix_from_csv_bytes
 
 
 @celery.task(base=TracedTask, ignore_result=True, args_as_tags=('project_id', 'run_id'))
-def solver_task(similarity_scores_filename, project_id, run_id, lenf1, lenf2, parent_span):
+def solver_task(similarity_scores_filename, project_id, run_id, dataset_sizes, parent_span):
     log = logger.bind(pid=project_id, run_id=run_id)
     mc = connect_to_object_store()
-    solver_task.span.log_kv({'lenf1': lenf1, 'lenf2': lenf2, 'filename': similarity_scores_filename})
+    solver_task.span.log_kv({'datasetSizes': dataset_sizes,
+                             'filename': similarity_scores_filename})
     score_file = mc.get_object(config.MINIO_BUCKET, similarity_scores_filename)
     log.debug("Creating python sparse matrix from bytes data")
     candidate_pairs = anonlink.serialization.load_candidate_pairs(score_file)
@@ -24,7 +25,6 @@ def solver_task(similarity_scores_filename, project_id, run_id, lenf1, lenf2, pa
 
     res = {
         "groups": groups,
-        "lenf1": lenf1,
-        "lenf2": lenf2
+        "datasetSizes": dataset_sizes
     }
     save_and_permute.delay(res, project_id, run_id, solver_task.get_serialized_span())


### PR DESCRIPTION
This generalises the worker functions to many parties, to make it easier to enable multi-party linkage. Changes to tests are not necessary as everything is equivalent for 2-party linkage.