### PR TITLE
Fix chunk merging (and one other minor thing)

### DIFF
--- a/backend/entityservice/models/project.py
+++ b/backend/entityservice/models/project.py
@@ -58,7 +58,7 @@ class Project(object):
         # Get optional fields from JSON data
         name = data.get('name', '')
         notes = data.get('notes', '')
-        parties = data.get('parties', 2)
+        parties = data.get('number_parties', 2)
 
         return Project(result_type, schema, name, notes, parties)
 

--- a/backend/entityservice/tasks/comparing.py
+++ b/backend/entityservice/tasks/comparing.py
@@ -240,7 +240,7 @@ def _merge_files(mc, log, file0, file1):
     except minio.ResponseError:
         log.warning("Failed to store merged result in minio.")
         raise
-    for del_err in minioClient.remove_objects(
+    for del_err in mc.remove_objects(
             Config.MINIO_BUCKET, (filename0, filename1)):
         log.warning(f"Failed to delete result file "
                     f"{del_err.object_name}. {del_err}")
@@ -279,7 +279,7 @@ def aggregate_comparisons(similarity_result_files, project_id, run_id, parent_sp
         if num:
             assert filesize is not None
             assert filename is not None
-            files.append(res)
+            files.append((num, filesize, filename))
         else:
             assert filesize is None
             assert filename is None


### PR DESCRIPTION
Two bugfixes:

1. The merging of similarities is currently crashing because of errors that were not caught by the tests. This is bad. These two line changes fix it.

2. Read `number_parties` correctly when making a project.