### PR TITLE
Have jenkins fail if the benchmark errors

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -165,7 +165,7 @@ node('docker&&multicore&&ram') {
           def benchmarkResults = readJSON file: 'results.json'
           print(benchmarkResults["version"])
           for (String item : benchmarkResults["experiments"]) {
-               if(item["status"] == "ERROR") {
+               if (item["status"] != "completed") {
                  throw new Exception("Benchmark failed\n" + item["description"])
                }
           }

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -23,5 +23,4 @@ USER user
 
 ADD . /app
 
-ENV SERVER https://testing.es.data61.xyz
 CMD python benchmark.py


### PR DESCRIPTION
- Fails if the benchmark container exits incorrectly (due to bad configuration).
- Fails if the benchmark results contain status=ERROR entries.
- Removes the default server address for benchmark container.

Closes #361