### PR TITLE
Fail on invalid result_type/number_parties combination

### DIFF
--- a/backend/entityservice/api_def/swagger.yaml
+++ b/backend/entityservice/api_def/swagger.yaml
@@ -770,6 +770,7 @@ definitions:
           If there are more than two data providers, then `result_type` must be
           `"groups"`.
         type: number
+        minimum: 2
       name:
         description: Any free text name for this project.
         type: string

--- a/backend/entityservice/api_def/swagger.yaml
+++ b/backend/entityservice/api_def/swagger.yaml
@@ -81,6 +81,9 @@ info:
         represents the likelihood that `indexA = indexB`.
       * `"groups"` - Outputs a list of groups of records, where each group represents one entity.
 
+    Only `"groups"` supports multi-party linkage. `"mapping"`, `"permutations"`, and `"similarity_scores"` only support linkage
+    with two parties.
+
 
 
 host: es.data61.xyz
@@ -198,6 +201,9 @@ paths:
         If the `result_type` is `permutations`, then the data providers can access their respective permutation with
         their individual `receipt_token`, which they obtain when adding data to the mapping.
         The mask can be accessed with the `result_token`.
+
+        Only `"groups"` supports multi-party linkage. If the result type is `"mapping"`,  `"similarity_scores"`, or
+        `"permutations"`, then the number of parties must be 2.
 
       parameters:
         - in: body
@@ -709,7 +715,8 @@ definitions:
 
   ResultType:
     type: string
-    description: defines the output type of the mapping
+    description: |
+      Defines the output type of the mapping. Multi-party linkage requires `"groups"` to be used.
     enum:
       - similarity_scores
       - mapping
@@ -758,7 +765,10 @@ definitions:
       result_type:
         $ref: '#/definitions/ResultType'
       number_parties:
-        description: How many data providers will participate in this project. Default value is 2.
+        description: |
+          How many data providers will participate in this project. Default value is 2.
+          If there are more than two data providers, then `result_type` must be
+          `"groups"`.
         type: number
       name:
         description: Any free text name for this project.

--- a/backend/entityservice/models/project.py
+++ b/backend/entityservice/models/project.py
@@ -60,6 +60,10 @@ class Project(object):
         notes = data.get('notes', '')
         parties = data.get('number_parties', 2)
 
+        if parties > 2 and result_type != 'groups':
+            raise InvalidProjectParametersException(
+                "Multi-party linkage requires result type 'groups'.")            
+
         return Project(result_type, schema, name, notes, parties)
 
     def save(self, conn):

--- a/backend/entityservice/tests/conftest.py
+++ b/backend/entityservice/tests/conftest.py
@@ -175,6 +175,8 @@ def groups_project(request, requests):
 
 
 @pytest.fixture(
-    params=itertools.product(PROJECT_RESULT_TYPES_2P, [3, 4, 5]))
+    params=itertools.chain(
+        itertools.product(PROJECT_RESULT_TYPES_2P, [1, 3, 4, 5]),
+        [(t, 1) for t in PROJECT_RESULT_TYPES_NP]))
 def invalid_result_type_number_parties(request):
     yield request.param

--- a/backend/entityservice/tests/conftest.py
+++ b/backend/entityservice/tests/conftest.py
@@ -127,6 +127,15 @@ def result_type_number_parties(request):
     yield request.param
 
 
+@pytest.fixture(params=(
+    *[(t, n) for t in PROJECT_RESULT_TYPES_2P
+             for n in (None, 2)],
+    *[(t, n) for t in PROJECT_RESULT_TYPES_NP
+             for n in (None, *NUMBERS_PARTIES)]))
+def result_type_number_parties_or_none(request):
+    yield request.param
+
+
 @pytest.fixture(scope='function')
 def project(request, requests, result_type_number_parties):
     result_type, number_parties = result_type_number_parties
@@ -163,3 +172,9 @@ def groups_project(request, requests):
     prj = create_project_response(requests, size, overlap, 'groups', encoding_size)
     yield prj
     delete_project(requests, prj)
+
+
+@pytest.fixture(
+    params=itertools.product(PROJECT_RESULT_TYPES_2P, [3, 4, 5]))
+def invalid_result_type_number_parties(request):
+    yield request.param

--- a/backend/entityservice/views/project.py
+++ b/backend/entityservice/views/project.py
@@ -205,10 +205,11 @@ def authorise_get_request(project_id):
     with DBConn() as dbinstance:
         project_object = db.get_project(dbinstance, project_id)
     logger.info("Checking credentials")
-    if project_object['result_type'] == 'mapping' or project_object['result_type'] == 'similarity_scores':
+    result_type = project_object['result_type']
+    if result_type in {'mapping', 'similarity_scores', 'groups'}:
         # Check the caller has a valid results token if we are including results
         abort_if_invalid_results_token(project_id, auth_header)
-    elif project_object['result_type'] == 'permutations':
+    elif result_type == 'permutations':
         dp_id = get_authorization_token_type_or_abort(project_id, auth_header)
     else:
         safe_fail_request(500, "Unknown error")


### PR DESCRIPTION
The only result type that works with multi-party linkage is `”groups”`. This PR makes a project POST request fail if `number_parties` > 2 but `result_type` ≠ groups.