### PR TITLE
Update alpine base image to 3.8

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 EXPOSE 8000
 ADD requirements.txt /var/www/requirements.txt


### PR DESCRIPTION
There are a couple of [minor CVE that quay.io has picked up](https://quay.io/repository/n1analytics/entity-app/manifest/sha256:0bd94c0f5917a634010c8a1cd159c8a5eeb7531d21015f4cca6a5bdfd73a937d?tab=vulnerabilities&fixable=true) in our packaged version of python3. 

I suspect updated alpine to 3.8 or 3.9 will be enough to fix them.

