### PR TITLE
Tweak database connection tear down and logging

### DIFF
--- a/backend/entityservice/__init__.py
+++ b/backend/entityservice/__init__.py
@@ -61,10 +61,13 @@ def before_request():
     g.flask_tracer = flask_tracer
 
 
-@app.teardown_request
-def teardown_request(exception):
-    if hasattr(g, 'db'):
-        g.db.close()
+@app.teardown_appcontext
+def close_db(error):
+    db = g.pop('db', None)
+
+    if db is not None:
+        g.log.info("tearing down database")
+        db.close()
 
 
 if __name__ == '__main__':

--- a/backend/entityservice/__init__.py
+++ b/backend/entityservice/__init__.py
@@ -66,7 +66,7 @@ def close_db(error):
     db = g.pop('db', None)
 
     if db is not None:
-        g.log.info("tearing down database")
+        g.log.debug("tearing down database")
         db.close()
 
 

--- a/backend/entityservice/__init__.py
+++ b/backend/entityservice/__init__.py
@@ -66,7 +66,9 @@ def close_db(error):
     db = g.pop('db', None)
 
     if db is not None:
-        g.log.debug("tearing down database")
+        g.log.debug("Closing database connection")
+        for notice in db.notices:
+            g.log.debug(notice)
         db.close()
 
 

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -49,7 +49,11 @@ def connect_db():
 
 
 def init_db(delay=0.5):
-    """Initializes the database."""
+    """
+    Initializes the database by creating the required tables.
+
+    @param float delay: Number of seconds to wait before executing the SQL.
+    """
     time.sleep(delay)
     db = connect_db()
     with current_app.open_resource('init-db-schema.sql', mode='r') as f:

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -64,8 +64,10 @@ def init_db(delay=0.5):
 
 class DBConn:
 
+    def __init__(self, conn=None):
+        self.conn = conn if conn is not None else connect_db()
+
     def __enter__(self):
-        self.conn = connect_db()
         return self.conn
 
     def __exit__(self, exc_type, exc_val, traceback):
@@ -73,7 +75,6 @@ class DBConn:
             self.conn.commit()
             for notice in self.conn.notices:
                 logger.debug(notice)
-            self.conn.close()
         else:
             # There was an exception in the DBConn body
             if isinstance(exc_type, psycopg2.Error):
@@ -100,7 +101,8 @@ def execute_returning_id(cur, query, args):
 
 def get_db():
     """Opens a new database connection if there is none yet for the
-    current flask application context.
+    current flask application context. The connection will be closed
+    at the end of the request.
     """
     conn = getattr(g, 'db', None)
     if conn is None:

--- a/backend/entityservice/error_checking.py
+++ b/backend/entityservice/error_checking.py
@@ -28,8 +28,6 @@ def check_dataproviders_encoding(project_id, encoding_size):
         """))
 
 
-
-
 def handle_invalid_encoding_data(project_id, dp_id):
     with DBConn() as conn:
         filename = get_filter_metadata(conn, dp_id)

--- a/backend/entityservice/logger_setup.py
+++ b/backend/entityservice/logger_setup.py
@@ -22,7 +22,7 @@ def setup_logging(
     except yaml.YAMLError as e:
         raise InvalidConfiguration("Parsing YAML logging config failed") from e
     except FileNotFoundError as e:
-        raise InvalidConfiguration("Logging config YAML file doesn't exist. Falling back to defaults") from e
+        raise InvalidConfiguration(f"Logging config YAML file '{path}' doesn't exist.") from e
 
     # Configure Structlog wrapper for client use
     setup_structlog()

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -20,7 +20,6 @@ class Config(object):
     LOGFILE = os.getenv("LOGFILE")
     LOG_HTTP_HEADER_FIELDS = os.getenv("LOG_HTTP_HEADER_FIELDS")
 
-
     REDIS_SERVER = os.getenv('REDIS_SERVER', 'redis')
     REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', '')
     REDIS_USE_SENTINEL = os.getenv('REDIS_USE_SENTINEL', 'false').lower() == "true"

--- a/backend/entityservice/tests/test_project.py
+++ b/backend/entityservice/tests/test_project.py
@@ -216,9 +216,9 @@ def test_invalid_result_type_number_parties_does_not_side_effect(
         invalid_result_type_number_parties):
     result_type, number_parties = invalid_result_type_number_parties
     
-    original_project_list_respose = requests.get(url + '/projects').json()
+    original_project_list_response = requests.get(url + '/projects').json()
     original_project_ids = {
-        p['project_id'] for p in original_project_list_respose}
+        p['project_id'] for p in original_project_list_response}
 
     requests.post(url + '/projects', json={
         'schema': {},

--- a/backend/entityservice/verbose_logging.yaml
+++ b/backend/entityservice/verbose_logging.yaml
@@ -52,14 +52,14 @@ loggers:
 
   entityservice.tasks:
     level: DEBUG
-    propagate: no
+    propagate: yes
 
-  entityservice.database.util:
-    level: WARNING
-    propagate: no
+  entityservice.database:
+    level: INFO
+    propagate: yes
 
   celery:
-    level: INFO
+    level: WARNING
     propogate: yes
 
   jaeger_tracing:

--- a/backend/entityservice/views/project.py
+++ b/backend/entityservice/views/project.py
@@ -41,12 +41,13 @@ def projects_post(project):
         project_model = models.Project.from_json(project)
         logger = logger.bind(pid=project_model.project_id)
     except models.InvalidProjectParametersException as e:
+        logger.info(f"Denied request to add a new project - {e.msg}", project=project)
         safe_fail_request(400, message=e.msg)
 
     # Persist the new project
     logger.info("Adding new project to database")
     try:
-        with DBConn() as conn:
+        with DBConn(get_db()) as conn:
             project_model.save(conn)
     except Exception as e:
         logger.warn(e)
@@ -65,7 +66,7 @@ def project_delete(project_id):
     abort_if_invalid_results_token(project_id, request.headers.get('Authorization'))
     log.info("Marking project for deletion")
 
-    with DBConn() as db_conn:
+    with DBConn(get_db()) as db_conn:
         db.mark_project_deleted(db_conn, project_id)
 
     log.info("Queuing authorized request to delete project resources")
@@ -82,7 +83,7 @@ def project_get(project_id):
     log.info("Getting detail for a project")
     abort_if_project_doesnt_exist(project_id)
     authorise_get_request(project_id)
-    with DBConn() as db_conn:
+    with DBConn(get_db()) as db_conn:
         project_object = db.get_project(db_conn, project_id)
         # Expose the number of data providers who have uploaded clks
         parties_contributed = db.get_number_parties_uploaded(db_conn, project_id)
@@ -116,9 +117,9 @@ def project_clks_post(project_id):
         # Check the caller has valid token -> otherwise 403
         abort_if_invalid_dataprovider_token(token)
 
-    with DBConn() as conn:
+    with DBConn(db.get_db()) as conn:
         dp_id = db.get_dataprovider_id(conn, token)
-        project_encoding_size = db.get_project_schema_encoding_size(get_db(), project_id)
+        project_encoding_size = db.get_project_schema_encoding_size(conn, project_id)
 
     log = log.bind(dp_id=dp_id)
     log.info("Receiving CLK data.")
@@ -202,7 +203,7 @@ def authorise_get_request(project_id):
     dp_id = None
     # Check the resource exists
     abort_if_project_doesnt_exist(project_id)
-    with DBConn() as dbinstance:
+    with DBConn(get_db()) as dbinstance:
         project_object = db.get_project(dbinstance, project_id)
     logger.info("Checking credentials")
     result_type = project_object['result_type']
@@ -224,7 +225,7 @@ def upload_clk_data_binary(project_id, dp_id, raw_stream, count, size=128):
     receipt_token = generate_code()
     filename = Config.BIN_FILENAME_FMT.format(receipt_token)
     # Set the state to 'pending' in the bloomingdata table
-    with DBConn() as conn:
+    with DBConn(get_db()) as conn:
         db.insert_encoding_metadata(conn, filename, dp_id, receipt_token, count)
         db.update_encoding_metadata_set_encoding_size(conn, dp_id, size)
     logger.info(f"Storing supplied binary clks of individual size {size} in file: {filename}")
@@ -237,7 +238,7 @@ def upload_clk_data_binary(project_id, dp_id, raw_stream, count, size=128):
     logger.info(f"Uploading {count} binary encodings to object store. Total size: {fmt_bytes(num_bytes)}")
     parent_span = g.flask_tracer.get_span()
 
-    with opentracing.tracer.start_span('save-to-minio', child_of=parent_span) as span:
+    with opentracing.tracer.start_span('save-to-minio', child_of=parent_span):
         mc = connect_to_object_store()
         try:
             mc.put_object(Config.MINIO_BUCKET, filename, data=raw_stream, length=num_bytes)
@@ -245,8 +246,8 @@ def upload_clk_data_binary(project_id, dp_id, raw_stream, count, size=128):
             logger.info("Mismatch between expected stream length and header info")
             raise ValueError("Mismatch between expected stream length and header info")
 
-    with opentracing.tracer.start_span('update-database', child_of=parent_span) as span:
-        with DBConn() as conn:
+    with opentracing.tracer.start_span('update-database', child_of=parent_span):
+        with DBConn(get_db()) as conn:
             db.update_encoding_metadata(conn, filename, dp_id, 'ready')
             db.set_dataprovider_upload_state(conn, dp_id, True)
 
@@ -294,7 +295,7 @@ def upload_json_clk_data(dp_id, clk_json, parent_span):
         )
 
     with opentracing.tracer.start_span('update-db', child_of=parent_span) as span:
-        with DBConn() as conn:
+        with DBConn(get_db()) as conn:
             db.insert_encoding_metadata(conn, filename, dp_id, receipt_token, count)
 
     return receipt_token, filename

--- a/backend/entityservice/views/run/list.py
+++ b/backend/entityservice/views/run/list.py
@@ -40,7 +40,7 @@ def post(project_id, run):
 
     log.debug("Saving run")
 
-    with db.DBConn() as db_conn:
+    with db.DBConn(get_db()) as db_conn:
         run_model.save(db_conn)
         project_object = db.get_project(db_conn, project_id)
         parties_contributed = db.get_number_parties_uploaded(db_conn, project_id)

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -15,8 +15,11 @@ The following named loggers are used:
 
 The following environment variables affect logging:
 
+* `LOG_CFG` - sets the path to a logging configuration file. There are two examples:
+  - `entityservice/default_logging.yaml`
+  - `entityservice/verbose_logging.yaml`
 * `DEBUG` - sets the logging level to debug for all application code.
-* `LOGFILE` - directs the log output to this file.
+* `LOGFILE` - directs the log output to this file instead of stdout.
 * `LOG_HTTP_HEADER_FIELDS` - HTTP headers to include in the application logs.
 
 Example logging output with `LOG_HTTP_HEADER_FIELDS=User-Agent,Host`::

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: quay.io/n1analytics/entity-app
     environment:
       - DEBUG=false
-      - LOG_CFG=entityservice/verbose_logging.yaml
+      #- LOG_CFG=entityservice/verbose_logging.yaml
       - DATABASE_PASSWORD=rX%QpV7Xgyrz
       - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
       - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -62,7 +62,7 @@ services:
       - DATABASE_PASSWORD=rX%QpV7Xgyrz
       - DEBUG=true
       - LOGGING_LEVEL=DEBUG
-      - LOG_CFG=entityservice/verbose_logging.yaml
+      #- LOG_CFG=entityservice/verbose_logging.yaml
       - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
       - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - CELERY_ACKS_LATE=true

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     image: quay.io/n1analytics/entity-app
     environment:
       - DEBUG=false
+      - LOG_CFG=entityservice/verbose_logging.yaml
       - DATABASE_PASSWORD=rX%QpV7Xgyrz
       - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
       - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -61,6 +62,7 @@ services:
       - DATABASE_PASSWORD=rX%QpV7Xgyrz
       - DEBUG=true
       - LOGGING_LEVEL=DEBUG
+      - LOG_CFG=entityservice/verbose_logging.yaml
       - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
       - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - CELERY_ACKS_LATE=true


### PR DESCRIPTION
I was [reading up on the flask Application Context](
http://flask.pocoo.org/docs/1.0/appcontext/#storing-data) and saw that the recommended approach for keeping a single database connection is slightly different to what we have.

I also added a debug log message to this teardown, and tweaked the *verbose logging* config so a developer can easily see the debug message. Note this changes the default docker-compose deployment to make including verbose logging a simple uncomment operation.

See also https://github.com/data61/anonlink-entity-service/issues/385