### PR TITLE
Feature pipeline integration tests

### DIFF
--- a/.azurePipeline/k8s_test_job.yaml.tmpl
+++ b/.azurePipeline/k8s_test_job.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
           env:
             - name: ENTITY_SERVICE_URL
               value: http://$SERVICE_IP/api/v1
-          command: ["dockerize", "-wait", "tcp://$SERVICE_IP:80/api/v1/status", "-timeout", "5m", "python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
+          command: ["dockerize", "-wait", "tcp://$SERVICE_IP/api/v1/status", "-timeout", "5m", "python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
           volumeMounts:
             - mountPath: /mnt
               name: results

--- a/.azurePipeline/k8s_test_job.yaml.tmpl
+++ b/.azurePipeline/k8s_test_job.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
           env:
             - name: ENTITY_SERVICE_URL
               value: http://$SERVICE_IP/api/v1
-          command: ["dockerize", "-wait", "tcp://$SERVICE_IP/api/v1/status", "-timeout", "5m", "python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
+          command: ["dockerize", "-wait", "tcp://$SERVICE_IP:80/api/v1/status", "-timeout", "5m", "python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
           volumeMounts:
             - mountPath: /mnt
               name: results

--- a/.azurePipeline/k8s_test_job.yaml.tmpl
+++ b/.azurePipeline/k8s_test_job.yaml.tmpl
@@ -33,6 +33,4 @@ spec:
           volumeMounts:
             - mountPath: /mnt
               name: results
-      imagePullSecrets:
-        - name: n1-quay-pull-secret
 

--- a/.azurePipeline/k8s_test_job.yaml.tmpl
+++ b/.azurePipeline/k8s_test_job.yaml.tmpl
@@ -29,7 +29,7 @@ spec:
           env:
             - name: ENTITY_SERVICE_URL
               value: http://$SERVICE_IP/api/v1
-          command: ["python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
+          command: ["dockerize", "-wait", "tcp://$SERVICE_IP/api/v1/status", "-timeout", "5m", "python", "-m", "pytest", "entityservice/tests", "-x", "--junit-xml=/mnt/results.xml"]
           volumeMounts:
             - mountPath: /mnt
               name: results

--- a/.azurePipeline/templateDockerBuildPush.yml
+++ b/.azurePipeline/templateDockerBuildPush.yml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  displayName: Building ${{ parameters.imageName }}
+  displayName: ${{ parameters.imageName }}
   pool:
     vmImage: "ubuntu-16.04"
 
@@ -21,6 +21,7 @@ jobs:
   - template: templateDockerTagFromBranch.yml
   - script: |
       docker login -u $(dockerHubId) -p $(dockerHubPassword)
+    displayName: 'Dockerhub login'
   - script: |
       if [[ -z "${{ parameters.dockerFilePath }}" ]]; then
         docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) ${{ parameters.folder }}
@@ -28,6 +29,7 @@ jobs:
         docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) -f ${{ parameters.dockerFilePath }} ${{ parameters.folder }}
       fi
       docker push ${{ parameters.imageName }}:$(DOCKER_TAG)
+    displayName: 'Create and push the image'
       
 # Updated from the documentation https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops
 # The idea being able to define jobs depending on the creation of the previous image.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,12 +41,12 @@ stages:
     parameters:
       folder: '.'
       dockerFilePath: './frontend/Dockerfile'
-      imageName: anonlink-nginx
+      imageName: data61/anonlink-nginx
       jobName: 'anonlink_nginx'
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './backend'
-      imageName: anonlink-app
+      imageName: data61/anonlink-app
       jobName: 'anonlink_app'
       
 - stage: stage_benchmark_image_build
@@ -56,7 +56,7 @@ stages:
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './benchmarking'
-      imageName: anonlink-benchmark
+      imageName: data61/anonlink-benchmark
       jobName: 'anonlink_benchmark'
       
 - stage: stage_docs_tutorial_image_build
@@ -66,7 +66,7 @@ stages:
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './docs/tutorial'
-      imageName: anonlink-docs-tutorials
+      imageName: data61/anonlink-docs-tutorials
       jobName: 'anonlink_docs_tutorials'
 
 #- stage: stage_integration_tests
@@ -165,7 +165,7 @@ stages:
     # Prepare all the variables required during the scripts.
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
-        echo $(DOCKER_TAG)$(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
+        echo $(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set some variables part 1'
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,7 +272,7 @@ stages:
     # Note that all the test resources (i.e. the pvc, the job and the pod has a label `deployment` set to $(DEPLOYMENT)
     - script: |
         echo "Delete all the test resources"
-        kubectl get pods,jobs,pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
+        kubectl delete pods,jobs,pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
       condition: always()
       env:
         KUBECONFIG: $(KUBECONFIGFILE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,12 +41,12 @@ stages:
     parameters:
       folder: '.'
       dockerFilePath: './frontend/Dockerfile'
-      imageName: $(frontendImageName)
+      imageName: anonlink-nginx
       jobName: 'anonlink_nginx'
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './backend'
-      imageName: $(backendImageName)
+      imageName: anonlink-app
       jobName: 'anonlink_app'
       
 - stage: stage_benchmark_image_build
@@ -56,7 +56,7 @@ stages:
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './benchmarking'
-      imageName: $(benchmarkingImageName)
+      imageName: anonlink-benchmark
       jobName: 'anonlink_benchmark'
       
 - stage: stage_docs_tutorial_image_build
@@ -66,7 +66,7 @@ stages:
   - template: .azurePipeline/templateDockerBuildPush.yml
     parameters:
       folder: './docs/tutorial'
-      imageName: $(tutorialImageName)
+      imageName: anonlink-docs-tutorials
       jobName: 'anonlink_docs_tutorials'
 
 #- stage: stage_integration_tests
@@ -84,6 +84,7 @@ stages:
 #    - template: .azurePipeline/templateDockerTagFromBranch.yml
 #    - script: |
 #        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
+#      displayName: 'Start docker compose tests'
 #    - task: PublishTestResults@2
 #      condition: succeededOrFailed()
 #      inputs:
@@ -102,13 +103,14 @@ stages:
     timeoutInMinutes: 15
     variables:
       resultFile: results.json
-    displayName: Benchmarking
+    displayName: Benchmark
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
         ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type benchmark
+      displayName: 'Start docker compose benchmark'
     # Publish Pipeline Artifact
     # Publish a local directory or file as a named artifact for the current pipeline.
     - task: PublishPipelineArtifact@0
@@ -133,6 +135,7 @@ stages:
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
         ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
+      displayName: 'Start docker compose tutorials tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
@@ -163,11 +166,13 @@ stages:
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
         echo "##vso[task.setvariable variable=DEPLOYMENT]deployment-$(DOCKER_TAG)$(Build.SourceVersion)"
+      displayName: 'Set some variables part 1'
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"
         echo "##vso[task.setvariable variable=PVC]$(DEPLOYMENT)-test-results"
         echo $(backendImageName):$(DOCKER_TAG) | xargs -I@ echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG]@"
         echo $(DOCKER_TAG)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
+      displayName: 'Set some variables part 2'
     # Start the whole service using helm. We are currently lucky, the helm version on azure is compatible with the one on our cluster, but the latest version of helm (Client 2.14.1) is not (tested from my laptop).
     - script: |
         echo "Start all the entity service pods"
@@ -186,6 +191,7 @@ stages:
                     --set workers.image.tag=$(DOCKER_TAG)
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Install the deployment on kubernetes'
     - script: |
         echo "Create Persistent Volume Claim"
         cat .azurePipeline/k8s_test_pvc.yaml.tmpl | \
@@ -194,10 +200,12 @@ stages:
         kubectl apply -n=$(NAMESPACE) -f -
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Create persistent volume claim for future results.'
     - script: |
         kubectl get services -n=$(NAMESPACE) -lapp=$(DEPLOYMENT)-entity-service -o jsonpath="{.items[0].spec.clusterIP}" | xargs -I@ echo "##vso[task.setvariable variable=SERVICE_IP]@"
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Set a variable for the service IP'
     - script: |
         echo "Start the test job"
         cat .azurePipeline/k8s_test_job.yaml.tmpl | \
@@ -210,6 +218,7 @@ stages:
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl logs -n=$(NAMESPACE) -f @
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Start the test job'
     - script: |
         echo "Get the test results"
         cat .azurePipeline/k8s_get_results.yaml.tmpl | \
@@ -222,6 +231,7 @@ stages:
         kubectl cp $(NAMESPACE)/$(POD_NAME):/mnt/results.xml k8s-results.xml
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Copy the results from the test job pod.'
     - task: PublishTestResults@2
       condition: succeeded()
       inputs:
@@ -239,7 +249,8 @@ stages:
         kubectl delete -n=$(NAMESPACE) -f -
       condition: always()
       env:
-        KUBECONFIG: $(KUBECONFIGFILE)  
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Delete the test job'
     - script: |
         echo "Delete the temp pod"
         cat .azurePipeline/k8s_get_results.yaml.tmpl | \
@@ -253,9 +264,11 @@ stages:
       condition: always()
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Delete the temp pod and the pvc'
     - script: |    
         echo "Delete everything"
         helm delete --purge $(DEPLOYMENT)
       condition: always()
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Purge the deployment'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,14 +181,14 @@ stages:
         helm init --client-only
         helm dependency update
         helm upgrade --install --wait --namespace $(NAMESPACE) $(DEPLOYMENT) . \
-                    -f values.yaml -f minimal-values.yaml \
-                    --set api.app.debug=true \
-                    --set global.postgresql.postgresqlPassword=notaproductionpassword \
-                    --set api.ingress.enabled=false \
-                    --set api.www.image.tag=$(DOCKER_TAG) \
-                    --set api.app.image.tag=$(DOCKER_TAG) \
-                    --set api.dbinit.image.tag=$(DOCKER_TAG) \
-                    --set workers.image.tag=$(DOCKER_TAG)
+        -f values.yaml -f minimal-values.yaml \
+        --set api.app.debug=true \
+        --set global.postgresql.postgresqlPassword=notaproductionpassword \
+        --set api.ingress.enabled=false \
+        --set api.www.image.tag=$(DOCKER_TAG) \
+        --set api.app.image.tag=$(DOCKER_TAG) \
+        --set api.dbinit.image.tag=$(DOCKER_TAG) \
+        --set workers.image.tag=$(DOCKER_TAG)
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Install the deployment on kubernetes'
@@ -213,7 +213,7 @@ stages:
         sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
         sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
         sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
-        kubectl apply -n=$(NAMESPACE) -f -
+        kubectl apply --wait -n=$(NAMESPACE) -f -
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl wait -n=$(NAMESPACE) --timeout=300s --for=condition=Ready pods/@
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl logs -n=$(NAMESPACE) -f @
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,7 +179,7 @@ stages:
       displayName: 'Initialize Helm'
     - script: |
         echo "Lint"
-        helm ling --debug --namespace $(NAMESPACE) $(DEPLOYMENT) . \
+        helm lint --debug --namespace $(NAMESPACE) $(DEPLOYMENT) . \
         -f values.yaml -f minimal-values.yaml \
         --set api.app.debug=true \
         --set global.postgresql.postgresqlPassword=notaproductionpassword \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ stages:
     # Prepare all the variables required during the scripts.
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
-        echo $(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
+        echo es$(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set some variables part 1'
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,8 +122,7 @@ stages:
 
 - stage: stage_k8s_deployment
   displayName: Kubernetes deployment
-  #dependsOn: [stage_docker_image_build]
-#  dependsOn: [stage_docker_image_build, stage_integration_tests]
+  dependsOn: [stage_docker_image_build]
   jobs:
   - job: job_k8s_deployment
     displayName: Kubernetes deployment and test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,7 @@ stages:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Create persistent volume claim for future results.'
     - script: |
-        kubectl get services -n=$(NAMESPACE) -lapp=$(DEPLOYMENT)-entity-service -o jsonpath="{.items[0].spec.clusterIP}" | xargs -I@ echo "##vso[task.setvariable variable=SERVICE_IP]@"
+        kubectl get services -n=$(NAMESPACE) -lapp=$(DEPLOYMENT)-entity-service -o jsonpath="{.items[0].spec.clusterIP}" | xargs -I@ echo "##vso[task.setvariable variable=SERVICE_IP]@:80"
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Set a variable for the service IP'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,28 +69,28 @@ stages:
       imageName: $(tutorialImageName)
       jobName: 'anonlink_docs_tutorials'
 
-- stage: stage_integration_tests
-  displayName: Integration tests
-  dependsOn: [stage_docker_image_build]
-  jobs:
-  - job: integration_test
-    timeoutInMinutes: 60
-    variables:
-      resultFile: testResults.xml
-    displayName: Integration tests
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-    - template: .azurePipeline/templateDockerTagFromBranch.yml
-    - script: |
-        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(resultFile)'
-        testRunTitle: 'Publish integration test results'
-        failTaskOnFailedTests: true
+#- stage: stage_integration_tests
+#  displayName: Integration tests
+#  dependsOn: [stage_docker_image_build]
+#  jobs:
+#  - job: integration_test
+#    timeoutInMinutes: 60
+#    variables:
+#      resultFile: testResults.xml
+#    displayName: Integration tests
+#    pool:
+#      vmImage: 'ubuntu-16.04'
+#    steps:
+#    - template: .azurePipeline/templateDockerTagFromBranch.yml
+#    - script: |
+#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
+#    - task: PublishTestResults@2
+#      condition: succeededOrFailed()
+#      inputs:
+#        testResultsFormat: 'JUnit'
+#        testResultsFiles: '$(resultFile)'
+#        testRunTitle: 'Publish integration test results'
+#        failTaskOnFailedTests: true
 
 - stage: stage_benchmark
   displayName: Benchmark
@@ -143,7 +143,8 @@ stages:
 
 - stage: stage_k8s_deployment
   displayName: Kubernetes deployment
-  dependsOn: [stage_docker_image_build, stage_integration_tests]
+  dependsOn: [stage_docker_image_build]
+#  dependsOn: [stage_docker_image_build, stage_integration_tests]
   jobs:
   - job: job_k8s_deployment
     displayName: Kubernetes deployment and test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ stages:
     # Prepare all the variables required during the scripts.
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
-        echo "##vso[task.setvariable variable=DEPLOYMENT]deployment-$(DOCKER_TAG)$(Build.SourceVersion)"
+        echo $(DOCKER_TAG)$(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set some variables part 1'
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,7 @@ stages:
       displayName: 'Create persistent volume claim for integration test results.'
     # Prepare helm
     - script: |
-        echo "Start all the entity service pods"
+        echo "Initialize Helm"
         cd deployment/entity-service
         helm version
         helm init --client-only
@@ -179,6 +179,8 @@ stages:
       displayName: 'Initialize Helm'
     - script: |
         echo "Lint"
+        cd deployment/entity-service
+        
         helm lint --debug --namespace $(NAMESPACE) $(DEPLOYMENT) . \
         -f values.yaml -f minimal-values.yaml \
         --set api.app.debug=true \
@@ -207,9 +209,6 @@ stages:
     - script: |
         echo "Start all the entity service pods"
         cd deployment/entity-service
-        helm version
-        helm init --client-only
-        helm dependency update
         helm upgrade --install --wait --namespace $(NAMESPACE) $(DEPLOYMENT) . \
         -f values.yaml -f minimal-values.yaml \
         --set api.app.debug=true \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ stages:
     # will use the deployment name as a prefix for their tags, adding extra suffixes. If the deployment name is too long, 
     # the tags may be longer than 63 characters which can fail the deployment with some warnings hard to see.
     - script: |
-        echo es$(Build.SourceVersion)| head -c 10 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
+        echo es$(Build.SourceVersion)| tr [:upper:] [:lower:] | tr -cd [a-z0-9] | head -c 10 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set variables part 1'
     # The task setting variables is split in two, because we cannot re-use directly a set variable in the same task
     # (in this case the value of $(DEPLOYMENT)).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,116 +33,116 @@ trigger:
     - '*'
 
 stages:
-- stage: stage_docker_image_build
-  displayName: Build docker images
-  dependsOn: []
-  jobs:
-  - template: .azurePipeline/templateDockerBuildPush.yml
-    parameters:
-      folder: '.'
-      dockerFilePath: './frontend/Dockerfile'
-      imageName: data61/anonlink-nginx
-      jobName: 'anonlink_nginx'
-  - template: .azurePipeline/templateDockerBuildPush.yml
-    parameters:
-      folder: './backend'
-      imageName: data61/anonlink-app
-      jobName: 'anonlink_app'
-      
-- stage: stage_benchmark_image_build
-  displayName: Build benchmark image
-  dependsOn: []
-  jobs:
-  - template: .azurePipeline/templateDockerBuildPush.yml
-    parameters:
-      folder: './benchmarking'
-      imageName: data61/anonlink-benchmark
-      jobName: 'anonlink_benchmark'
-      
-- stage: stage_docs_tutorial_image_build
-  displayName: Build docs tutorials image
-  dependsOn: []
-  jobs:
-  - template: .azurePipeline/templateDockerBuildPush.yml
-    parameters:
-      folder: './docs/tutorial'
-      imageName: data61/anonlink-docs-tutorials
-      jobName: 'anonlink_docs_tutorials'
-
-#- stage: stage_integration_tests
-#  displayName: Integration tests
-#  dependsOn: [stage_docker_image_build]
+#- stage: stage_docker_image_build
+#  displayName: Build docker images
+#  dependsOn: []
 #  jobs:
-#  - job: integration_test
-#    timeoutInMinutes: 60
+#  - template: .azurePipeline/templateDockerBuildPush.yml
+#    parameters:
+#      folder: '.'
+#      dockerFilePath: './frontend/Dockerfile'
+#      imageName: data61/anonlink-nginx
+#      jobName: 'anonlink_nginx'
+#  - template: .azurePipeline/templateDockerBuildPush.yml
+#    parameters:
+#      folder: './backend'
+#      imageName: data61/anonlink-app
+#      jobName: 'anonlink_app'
+#
+#- stage: stage_benchmark_image_build
+#  displayName: Build benchmark image
+#  dependsOn: []
+#  jobs:
+#  - template: .azurePipeline/templateDockerBuildPush.yml
+#    parameters:
+#      folder: './benchmarking'
+#      imageName: data61/anonlink-benchmark
+#      jobName: 'anonlink_benchmark'
+#
+#- stage: stage_docs_tutorial_image_build
+#  displayName: Build docs tutorials image
+#  dependsOn: []
+#  jobs:
+#  - template: .azurePipeline/templateDockerBuildPush.yml
+#    parameters:
+#      folder: './docs/tutorial'
+#      imageName: data61/anonlink-docs-tutorials
+#      jobName: 'anonlink_docs_tutorials'
+#
+##- stage: stage_integration_tests
+##  displayName: Integration tests
+##  dependsOn: [stage_docker_image_build]
+##  jobs:
+##  - job: integration_test
+##    timeoutInMinutes: 60
+##    variables:
+##      resultFile: testResults.xml
+##    displayName: Integration tests
+##    pool:
+##      vmImage: 'ubuntu-16.04'
+##    steps:
+##    - template: .azurePipeline/templateDockerTagFromBranch.yml
+##    - script: |
+##        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
+##      displayName: 'Start docker compose tests'
+##    - task: PublishTestResults@2
+##      condition: succeededOrFailed()
+##      inputs:
+##        testResultsFormat: 'JUnit'
+##        testResultsFiles: '$(resultFile)'
+##        testRunTitle: 'Publish integration test results'
+##        failTaskOnFailedTests: true
+#
+#- stage: stage_benchmark
+#  displayName: Benchmark
+#  dependsOn:
+#  - stage_docker_image_build
+#  - stage_benchmark_image_build
+#  jobs:
+#  - job: Benchmark
+#    timeoutInMinutes: 15
 #    variables:
-#      resultFile: testResults.xml
-#    displayName: Integration tests
+#      resultFile: results.json
+#    displayName: Benchmark
 #    pool:
 #      vmImage: 'ubuntu-16.04'
 #    steps:
 #    - template: .azurePipeline/templateDockerTagFromBranch.yml
 #    - script: |
-#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
-#      displayName: 'Start docker compose tests'
+#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type benchmark
+#      displayName: 'Start docker compose benchmark'
+#    # Publish Pipeline Artifact
+#    # Publish a local directory or file as a named artifact for the current pipeline.
+#    - task: PublishPipelineArtifact@0
+#      inputs:
+#        artifactName: 'benchmark'
+#        targetPath: $(resultFile)
+#
+#- stage: stage_tutorials_tests
+#  displayName: Tutorials tests
+#  dependsOn:
+#  - stage_docker_image_build
+#  - stage_docs_tutorial_image_build
+#  jobs:
+#  - job: TutorialsTests
+#    timeoutInMinutes: 10
+#    variables:
+#      resultFile: tutorialTestResults.xml
+#    displayName: Tutorials Tests
+#    pool:
+#      vmImage: 'ubuntu-16.04'
+#    steps:
+#    - template: .azurePipeline/templateDockerTagFromBranch.yml
+#    - script: |
+#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
+#      displayName: 'Start docker compose tutorials tests'
 #    - task: PublishTestResults@2
 #      condition: succeededOrFailed()
 #      inputs:
 #        testResultsFormat: 'JUnit'
 #        testResultsFiles: '$(resultFile)'
-#        testRunTitle: 'Publish integration test results'
+#        testRunTitle: 'Publish tutorials tests results'
 #        failTaskOnFailedTests: true
-
-- stage: stage_benchmark
-  displayName: Benchmark
-  dependsOn: 
-  - stage_docker_image_build
-  - stage_benchmark_image_build
-  jobs:
-  - job: Benchmark
-    timeoutInMinutes: 15
-    variables:
-      resultFile: results.json
-    displayName: Benchmark
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-    - template: .azurePipeline/templateDockerTagFromBranch.yml
-    - script: |
-        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type benchmark
-      displayName: 'Start docker compose benchmark'
-    # Publish Pipeline Artifact
-    # Publish a local directory or file as a named artifact for the current pipeline.
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'benchmark'
-        targetPath: $(resultFile)
-
-- stage: stage_tutorials_tests
-  displayName: Tutorials tests
-  dependsOn: 
-  - stage_docker_image_build
-  - stage_docs_tutorial_image_build
-  jobs:
-  - job: TutorialsTests
-    timeoutInMinutes: 10
-    variables:
-      resultFile: tutorialTestResults.xml
-    displayName: Tutorials Tests
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-    - template: .azurePipeline/templateDockerTagFromBranch.yml
-    - script: |
-        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
-      displayName: 'Start docker compose tutorials tests'
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: '$(resultFile)'
-        testRunTitle: 'Publish tutorials tests results'
-        failTaskOnFailedTests: true
 
 - stage: stage_k8s_deployment
   displayName: Kubernetes deployment
@@ -173,7 +173,15 @@ stages:
         echo $(backendImageName):$(DOCKER_TAG) | xargs -I@ echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG]@"
         echo $(DOCKER_TAG)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
       displayName: 'Set some variables part 2'
-    # Start the whole service using helm. We are currently lucky, the helm version on azure is compatible with the one on our cluster, but the latest version of helm (Client 2.14.1) is not (tested from my laptop).
+    - script: |
+        echo "Create Persistent Volume Claim"
+        cat .azurePipeline/k8s_test_pvc.yaml.tmpl | \
+        sed 's|\$PVC'"|$(PVC)|g" | \
+        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
+        kubectl apply --wait=true -n=$(NAMESPACE) -f -
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Create persistent volume claim for future results.'
     - script: |
         echo "Start all the entity service pods"
         cd deployment/entity-service
@@ -193,15 +201,6 @@ stages:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Install the deployment on kubernetes'
     - script: |
-        echo "Create Persistent Volume Claim"
-        cat .azurePipeline/k8s_test_pvc.yaml.tmpl | \
-        sed 's|\$PVC'"|$(PVC)|g" | \
-        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-        kubectl apply -n=$(NAMESPACE) -f -
-      env:
-        KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Create persistent volume claim for future results.'
-    - script: |
         kubectl get services -n=$(NAMESPACE) -lapp=$(DEPLOYMENT)-entity-service -o jsonpath="{.items[0].spec.clusterIP}" | xargs -I@ echo "##vso[task.setvariable variable=SERVICE_IP]@:80"
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
@@ -213,7 +212,7 @@ stages:
         sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
         sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
         sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
-        kubectl apply --wait -n=$(NAMESPACE) -f -
+        kubectl apply --wait=true -n=$(NAMESPACE) -f -
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl wait -n=$(NAMESPACE) --timeout=300s --for=condition=Ready pods/@
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl logs -n=$(NAMESPACE) -f @
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
     displayName: Kubernetes deployment and test
     timeoutInMinutes: 40
     variables:
-     NAMESPACE: test-azure
+      NAMESPACE: test-azure
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -214,7 +214,7 @@ stages:
         sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
         sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
         kubectl apply -n=$(NAMESPACE) -f -
-        kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl wait -n=$(NAMESPACE) --timeout=120s --for=condition=Ready pods/@
+        kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl wait -n=$(NAMESPACE) --timeout=300s --for=condition=Ready pods/@
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl logs -n=$(NAMESPACE) -f @
       env:
         KUBECONFIG: $(KUBECONFIGFILE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,30 +69,6 @@ stages:
       imageName: data61/anonlink-docs-tutorials
       jobName: 'anonlink_docs_tutorials'
 
-#- stage: stage_integration_tests
-#  displayName: Integration tests
-#  dependsOn: [stage_docker_image_build]
-#  jobs:
-#  - job: integration_test
-#    timeoutInMinutes: 60
-#    variables:
-#      resultFile: testResults.xml
-#    displayName: Integration tests
-#    pool:
-#      vmImage: 'ubuntu-16.04'
-#    steps:
-#    - template: .azurePipeline/templateDockerTagFromBranch.yml
-#    - script: |
-#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
-#      displayName: 'Start docker compose tests'
-#    - task: PublishTestResults@2
-#      condition: succeededOrFailed()
-#      inputs:
-#        testResultsFormat: 'JUnit'
-#        testResultsFiles: '$(resultFile)'
-#        testRunTitle: 'Publish integration test results'
-#        failTaskOnFailedTests: true
-
 - stage: stage_benchmark
   displayName: Benchmark
   dependsOn:
@@ -152,6 +128,8 @@ stages:
   - job: job_k8s_deployment
     displayName: Kubernetes deployment and test
     timeoutInMinutes: 40
+    # All the deployments for tests are done in the namespace `test-azure`, simplying
+    # debugging or cleaning if something wrong happens.
     variables:
       NAMESPACE: test-azure
     pool:
@@ -164,15 +142,23 @@ stages:
         secureFile: awsClusterConfig
     # Prepare all the variables required during the scripts.
     - template: .azurePipeline/templateDockerTagFromBranch.yml
+    # We are selecting a deployment name to be unique, not to have collision when pushing multiple times on the same branch
+    # So we are using the git commit hash. BUT, a k8s deployment MUST start with a letter, so added `es` to start its name, 
+    # then it needs to be short enough not to fail other tags built from it. In fact, most of the created objects from the templates
+    # will use the deployment name as a prefix for their tags, adding extra suffixes. If the deployment name is too long, 
+    # the tags may be longer than 63 characters which can fail the deployment with some warnings hard to see.
     - script: |
         echo es$(Build.SourceVersion)| head -c 10 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set some variables part 1'
+    # The task setting variables is split in two, because we cannot re-use directly a set variable in the same task
+    # (in this case the value of $(DEPLOYMENT)).
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"
         echo "##vso[task.setvariable variable=PVC]$(DEPLOYMENT)-test-results"
         echo $(backendImageName):$(DOCKER_TAG) | xargs -I@ echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG]@"
         echo $(DEPLOYMENT)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
       displayName: 'Set some variables part 2'
+    # The file `.azurePipeline/k8s_test_pvc.yaml.tmpl` is a template for the creation of persistent volume via kubectl
     - script: |
         echo "Create Persistent Volume Claim"
         cat .azurePipeline/k8s_test_pvc.yaml.tmpl | \
@@ -182,6 +168,8 @@ stages:
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Create persistent volume claim for future results.'
+    # Starting the whole entity-service
+    # Note that helm need to be initialised first.
     - script: |
         echo "Start all the entity service pods"
         cd deployment/entity-service
@@ -200,11 +188,15 @@ stages:
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Install the deployment on kubernetes'
+    # Task to get the IP of the service, which is require to run the test.
+    # Note that the port 80 is added at the end. This is in fact required for the command `dockerize -wait` to wait for a service before starting one.
     - script: |
         kubectl get services -n=$(NAMESPACE) -lapp=$(DEPLOYMENT)-entity-service -o jsonpath="{.items[0].spec.clusterIP}" | xargs -I@ echo "##vso[task.setvariable variable=SERVICE_IP]@:80"
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Set a variable for the service IP'
+    # The file `.azurePipeline/k8s_test_job.yaml.tmpl` is a template for the creation of the test job.
+    # The test job stops when all the tests have been ran, creating a test result file in the PVC.
     - script: |
         echo "Start the test job"
         cat .azurePipeline/k8s_test_job.yaml.tmpl | \
@@ -218,6 +210,10 @@ stages:
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Start the test job'
+    # That is still something fun with kubernetes, we cannot copy a file from a stopped container in a pod (while this is possible with docker), which is
+    # why we are creating a persistent volume, running the test job using the volume, and finally starting a container to be up with the mounted
+    # volume and use `kubectl cp` on it while it still runs.
+    # This is tracked in https://github.com/kubernetes/kubectl/issues/454 but has been in April 2018, its priority raised in June 2019.
     - script: |
         echo "Get the test results"
         cat .azurePipeline/k8s_get_results.yaml.tmpl | \
@@ -231,6 +227,7 @@ stages:
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Copy the results from the test job pod.'
+    # Finally, we can publish the test results.
     - task: PublishTestResults@2
       condition: succeeded()
       inputs:
@@ -238,6 +235,7 @@ stages:
         testResultsFiles: 'k8s-results.xml'
         testRunTitle: 'Publish kubernetes test results'
         failTaskOnFailedTests: true 
+    # And do a lot of cleaning.
     - script: |
         echo "Delete the test job"
         cat .azurePipeline/k8s_test_job.yaml.tmpl | \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
 
 - stage: stage_k8s_deployment
   displayName: Kubernetes deployment
-  dependsOn: [stage_docker_image_build]
+  #dependsOn: [stage_docker_image_build]
 #  dependsOn: [stage_docker_image_build, stage_integration_tests]
   jobs:
   - job: job_k8s_deployment
@@ -171,7 +171,7 @@ stages:
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"
         echo "##vso[task.setvariable variable=PVC]$(DEPLOYMENT)-test-results"
         echo $(backendImageName):$(DOCKER_TAG) | xargs -I@ echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG]@"
-        echo $(DOCKER_TAG)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
+        echo $(DEPLOYMENT)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
       displayName: 'Set some variables part 2'
     - script: |
         echo "Create Persistent Volume Claim"
@@ -238,36 +238,36 @@ stages:
         testResultsFiles: 'k8s-results.xml'
         testRunTitle: 'Publish kubernetes test results'
         failTaskOnFailedTests: true 
-    - script: |
-        echo "Delete the test job"
-        cat .azurePipeline/k8s_test_job.yaml.tmpl | \
-        sed 's|\$PVC'"|$(PVC)|g" | \
-        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-        sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
-        sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
-        kubectl delete -n=$(NAMESPACE) -f -
-      condition: always()
-      env:
-        KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Delete the test job'
-    - script: |
-        echo "Delete the temp pod"
-        cat .azurePipeline/k8s_get_results.yaml.tmpl | \
-        sed 's|\$PVC'"|$(PVC)|g" | \
-        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-        sed 's|\$POD_NAME'"|$(POD_NAME)|g" | \
-        kubectl delete -n=$(NAMESPACE) -f -
-        
-        echo "Delete the pvc"
-        kubectl delete pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
-      condition: always()
-      env:
-        KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Delete the temp pod and the pvc'
-    - script: |    
-        echo "Delete everything"
-        helm delete --purge $(DEPLOYMENT)
-      condition: always()
-      env:
-        KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Purge the deployment'
+#    - script: |
+#        echo "Delete the test job"
+#        cat .azurePipeline/k8s_test_job.yaml.tmpl | \
+#        sed 's|\$PVC'"|$(PVC)|g" | \
+#        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
+#        sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
+#        sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
+#        kubectl delete -n=$(NAMESPACE) -f -
+#      condition: always()
+#      env:
+#        KUBECONFIG: $(KUBECONFIGFILE)
+#      displayName: 'Delete the test job'
+#    - script: |
+#        echo "Delete the temp pod"
+#        cat .azurePipeline/k8s_get_results.yaml.tmpl | \
+#        sed 's|\$PVC'"|$(PVC)|g" | \
+#        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
+#        sed 's|\$POD_NAME'"|$(POD_NAME)|g" | \
+#        kubectl delete -n=$(NAMESPACE) -f -
+#
+#        echo "Delete the pvc"
+#        kubectl delete pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
+#      condition: always()
+#      env:
+#        KUBECONFIG: $(KUBECONFIGFILE)
+#      displayName: 'Delete the temp pod and the pvc'
+#    - script: |
+#        echo "Delete everything"
+#        helm delete --purge $(DEPLOYMENT)
+#      condition: always()
+#      env:
+#        KUBECONFIG: $(KUBECONFIGFILE)
+#      displayName: 'Purge the deployment'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
         ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
-      displayName: 'Start docker compose tutorials tests'
+      displayName: 'Test notebook tutorials'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
@@ -148,7 +148,7 @@ stages:
     # the tags may be longer than 63 characters which can fail the deployment with some warnings hard to see.
     - script: |
         echo es$(Build.SourceVersion)| head -c 10 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
-      displayName: 'Set some variables part 1'
+      displayName: 'Set variables part 1'
     # The task setting variables is split in two, because we cannot re-use directly a set variable in the same task
     # (in this case the value of $(DEPLOYMENT)).
     - script: |
@@ -156,7 +156,7 @@ stages:
         echo "##vso[task.setvariable variable=PVC]$(DEPLOYMENT)-test-results"
         echo $(backendImageName):$(DOCKER_TAG) | xargs -I@ echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG]@"
         echo $(DEPLOYMENT)-tmppod | xargs -I@ echo "##vso[task.setvariable variable=POD_NAME]@"
-      displayName: 'Set some variables part 2'
+      displayName: 'Set variables part 2'
     # The file `.azurePipeline/k8s_test_pvc.yaml.tmpl` is a template for the creation of persistent volume via kubectl
     - script: |
         echo "Create Persistent Volume Claim"
@@ -166,7 +166,42 @@ stages:
         kubectl apply --wait=true -n=$(NAMESPACE) -f -
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Create persistent volume claim for future results.'
+      displayName: 'Create persistent volume claim for integration test results.'
+    # Prepare helm
+    - script: |
+        echo "Start all the entity service pods"
+        cd deployment/entity-service
+        helm version
+        helm init --client-only
+        helm dependency update
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Initialize Helm'
+    - script: |
+        echo "Lint"
+        helm ling --debug --namespace $(NAMESPACE) $(DEPLOYMENT) . \
+        -f values.yaml -f minimal-values.yaml \
+        --set api.app.debug=true \
+        --set global.postgresql.postgresqlPassword=notaproductionpassword \
+        --set api.ingress.enabled=false \
+        --set api.www.image.tag=$(DOCKER_TAG) \
+        --set api.app.image.tag=$(DOCKER_TAG) \
+        --set api.dbinit.image.tag=$(DOCKER_TAG) \
+        --set workers.image.tag=$(DOCKER_TAG)
+        
+        echo "Dry run"
+        helm upgrade --install --dry-run --wait --namespace $(NAMESPACE) $(DEPLOYMENT) . \
+        -f values.yaml -f minimal-values.yaml \
+        --set api.app.debug=true \
+        --set global.postgresql.postgresqlPassword=notaproductionpassword \
+        --set api.ingress.enabled=false \
+        --set api.www.image.tag=$(DOCKER_TAG) \
+        --set api.app.image.tag=$(DOCKER_TAG) \
+        --set api.dbinit.image.tag=$(DOCKER_TAG) \
+        --set workers.image.tag=$(DOCKER_TAG)
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Lint and dry-run'
     # Starting the whole entity-service
     # Note that helm need to be initialised first.
     - script: |
@@ -186,7 +221,7 @@ stages:
         --set workers.image.tag=$(DOCKER_TAG)
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Install the deployment on kubernetes'
+      displayName: 'Kubernetes deployment'
     # Task to get the IP of the service, which is require to run the test.
     # Note that the port 80 is added at the end. This is in fact required for the command `dockerize -wait` to wait for a service before starting one.
     - script: |
@@ -195,7 +230,7 @@ stages:
         KUBECONFIG: $(KUBECONFIGFILE)
       displayName: 'Set a variable for the service IP'
     # The file `.azurePipeline/k8s_test_job.yaml.tmpl` is a template for the creation of the test job.
-    # The test job stops when all the tests have been ran, creating a test result file in the PVC.
+    # The test job stops when all the tests have been run, creating a test result file in the PVC.
     - script: |
         echo "Start the test job"
         cat .azurePipeline/k8s_test_job.yaml.tmpl | \
@@ -208,7 +243,7 @@ stages:
         kubectl get pods -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT) -o jsonpath="{.items[0].metadata.name}" | xargs -I@ kubectl logs -n=$(NAMESPACE) -f @
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Start the test job'
+      displayName: 'Run integration tests'
     # That is still something fun with kubernetes, we cannot copy a file from a stopped container in a pod (while this is possible with docker), which is
     # why we are creating a persistent volume, running the test job using the volume, and finally starting a container to be up with the mounted
     # volume and use `kubectl cp` on it while it still runs.
@@ -235,34 +270,16 @@ stages:
         testRunTitle: 'Publish kubernetes test results'
         failTaskOnFailedTests: true 
     # And do a lot of cleaning.
+    # Note that all the test resources (i.e. the pvc, the job and the pod has a label `deployment` set to $(DEPLOYMENT)
     - script: |
-        echo "Delete the test job"
-        cat .azurePipeline/k8s_test_job.yaml.tmpl | \
-        sed 's|\$PVC'"|$(PVC)|g" | \
-        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-        sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
-        sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
-        kubectl delete -n=$(NAMESPACE) -f -
+        echo "Delete all the test resources"
+        kubectl get pods,jobs,pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
       condition: always()
       env:
         KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Delete the test job'
+      displayName: 'Delete the test resources'
     - script: |
-        echo "Delete the temp pod"
-        cat .azurePipeline/k8s_get_results.yaml.tmpl | \
-        sed 's|\$PVC'"|$(PVC)|g" | \
-        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-        sed 's|\$POD_NAME'"|$(POD_NAME)|g" | \
-        kubectl delete -n=$(NAMESPACE) -f -
-
-        echo "Delete the pvc"
-        kubectl delete pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
-      condition: always()
-      env:
-        KUBECONFIG: $(KUBECONFIGFILE)
-      displayName: 'Delete the temp pod and the pvc'
-    - script: |
-        echo "Delete everything"
+        echo "Delete the deployment"
         helm delete --purge $(DEPLOYMENT)
       condition: always()
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,116 +33,116 @@ trigger:
     - '*'
 
 stages:
-#- stage: stage_docker_image_build
-#  displayName: Build docker images
-#  dependsOn: []
+- stage: stage_docker_image_build
+  displayName: Build docker images
+  dependsOn: []
+  jobs:
+  - template: .azurePipeline/templateDockerBuildPush.yml
+    parameters:
+      folder: '.'
+      dockerFilePath: './frontend/Dockerfile'
+      imageName: data61/anonlink-nginx
+      jobName: 'anonlink_nginx'
+  - template: .azurePipeline/templateDockerBuildPush.yml
+    parameters:
+      folder: './backend'
+      imageName: data61/anonlink-app
+      jobName: 'anonlink_app'
+
+- stage: stage_benchmark_image_build
+  displayName: Build benchmark image
+  dependsOn: []
+  jobs:
+  - template: .azurePipeline/templateDockerBuildPush.yml
+    parameters:
+      folder: './benchmarking'
+      imageName: data61/anonlink-benchmark
+      jobName: 'anonlink_benchmark'
+
+- stage: stage_docs_tutorial_image_build
+  displayName: Build docs tutorials image
+  dependsOn: []
+  jobs:
+  - template: .azurePipeline/templateDockerBuildPush.yml
+    parameters:
+      folder: './docs/tutorial'
+      imageName: data61/anonlink-docs-tutorials
+      jobName: 'anonlink_docs_tutorials'
+
+#- stage: stage_integration_tests
+#  displayName: Integration tests
+#  dependsOn: [stage_docker_image_build]
 #  jobs:
-#  - template: .azurePipeline/templateDockerBuildPush.yml
-#    parameters:
-#      folder: '.'
-#      dockerFilePath: './frontend/Dockerfile'
-#      imageName: data61/anonlink-nginx
-#      jobName: 'anonlink_nginx'
-#  - template: .azurePipeline/templateDockerBuildPush.yml
-#    parameters:
-#      folder: './backend'
-#      imageName: data61/anonlink-app
-#      jobName: 'anonlink_app'
-#
-#- stage: stage_benchmark_image_build
-#  displayName: Build benchmark image
-#  dependsOn: []
-#  jobs:
-#  - template: .azurePipeline/templateDockerBuildPush.yml
-#    parameters:
-#      folder: './benchmarking'
-#      imageName: data61/anonlink-benchmark
-#      jobName: 'anonlink_benchmark'
-#
-#- stage: stage_docs_tutorial_image_build
-#  displayName: Build docs tutorials image
-#  dependsOn: []
-#  jobs:
-#  - template: .azurePipeline/templateDockerBuildPush.yml
-#    parameters:
-#      folder: './docs/tutorial'
-#      imageName: data61/anonlink-docs-tutorials
-#      jobName: 'anonlink_docs_tutorials'
-#
-##- stage: stage_integration_tests
-##  displayName: Integration tests
-##  dependsOn: [stage_docker_image_build]
-##  jobs:
-##  - job: integration_test
-##    timeoutInMinutes: 60
-##    variables:
-##      resultFile: testResults.xml
-##    displayName: Integration tests
-##    pool:
-##      vmImage: 'ubuntu-16.04'
-##    steps:
-##    - template: .azurePipeline/templateDockerTagFromBranch.yml
-##    - script: |
-##        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
-##      displayName: 'Start docker compose tests'
-##    - task: PublishTestResults@2
-##      condition: succeededOrFailed()
-##      inputs:
-##        testResultsFormat: 'JUnit'
-##        testResultsFiles: '$(resultFile)'
-##        testRunTitle: 'Publish integration test results'
-##        failTaskOnFailedTests: true
-#
-#- stage: stage_benchmark
-#  displayName: Benchmark
-#  dependsOn:
-#  - stage_docker_image_build
-#  - stage_benchmark_image_build
-#  jobs:
-#  - job: Benchmark
-#    timeoutInMinutes: 15
+#  - job: integration_test
+#    timeoutInMinutes: 60
 #    variables:
-#      resultFile: results.json
-#    displayName: Benchmark
+#      resultFile: testResults.xml
+#    displayName: Integration tests
 #    pool:
 #      vmImage: 'ubuntu-16.04'
 #    steps:
 #    - template: .azurePipeline/templateDockerTagFromBranch.yml
 #    - script: |
-#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type benchmark
-#      displayName: 'Start docker compose benchmark'
-#    # Publish Pipeline Artifact
-#    # Publish a local directory or file as a named artifact for the current pipeline.
-#    - task: PublishPipelineArtifact@0
-#      inputs:
-#        artifactName: 'benchmark'
-#        targetPath: $(resultFile)
-#
-#- stage: stage_tutorials_tests
-#  displayName: Tutorials tests
-#  dependsOn:
-#  - stage_docker_image_build
-#  - stage_docs_tutorial_image_build
-#  jobs:
-#  - job: TutorialsTests
-#    timeoutInMinutes: 10
-#    variables:
-#      resultFile: tutorialTestResults.xml
-#    displayName: Tutorials Tests
-#    pool:
-#      vmImage: 'ubuntu-16.04'
-#    steps:
-#    - template: .azurePipeline/templateDockerTagFromBranch.yml
-#    - script: |
-#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
-#      displayName: 'Start docker compose tutorials tests'
+#        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tests
+#      displayName: 'Start docker compose tests'
 #    - task: PublishTestResults@2
 #      condition: succeededOrFailed()
 #      inputs:
 #        testResultsFormat: 'JUnit'
 #        testResultsFiles: '$(resultFile)'
-#        testRunTitle: 'Publish tutorials tests results'
+#        testRunTitle: 'Publish integration test results'
 #        failTaskOnFailedTests: true
+
+- stage: stage_benchmark
+  displayName: Benchmark
+  dependsOn:
+  - stage_docker_image_build
+  - stage_benchmark_image_build
+  jobs:
+  - job: Benchmark
+    timeoutInMinutes: 15
+    variables:
+      resultFile: results.json
+    displayName: Benchmark
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+    - template: .azurePipeline/templateDockerTagFromBranch.yml
+    - script: |
+        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type benchmark
+      displayName: 'Start docker compose benchmark'
+    # Publish Pipeline Artifact
+    # Publish a local directory or file as a named artifact for the current pipeline.
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'benchmark'
+        targetPath: $(resultFile)
+
+- stage: stage_tutorials_tests
+  displayName: Tutorials tests
+  dependsOn:
+  - stage_docker_image_build
+  - stage_docs_tutorial_image_build
+  jobs:
+  - job: TutorialsTests
+    timeoutInMinutes: 10
+    variables:
+      resultFile: tutorialTestResults.xml
+    displayName: Tutorials Tests
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+    - template: .azurePipeline/templateDockerTagFromBranch.yml
+    - script: |
+        ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type tutorials
+      displayName: 'Start docker compose tutorials tests'
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: '$(resultFile)'
+        testRunTitle: 'Publish tutorials tests results'
+        failTaskOnFailedTests: true
 
 - stage: stage_k8s_deployment
   displayName: Kubernetes deployment
@@ -238,36 +238,36 @@ stages:
         testResultsFiles: 'k8s-results.xml'
         testRunTitle: 'Publish kubernetes test results'
         failTaskOnFailedTests: true 
-#    - script: |
-#        echo "Delete the test job"
-#        cat .azurePipeline/k8s_test_job.yaml.tmpl | \
-#        sed 's|\$PVC'"|$(PVC)|g" | \
-#        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-#        sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
-#        sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
-#        kubectl delete -n=$(NAMESPACE) -f -
-#      condition: always()
-#      env:
-#        KUBECONFIG: $(KUBECONFIGFILE)
-#      displayName: 'Delete the test job'
-#    - script: |
-#        echo "Delete the temp pod"
-#        cat .azurePipeline/k8s_get_results.yaml.tmpl | \
-#        sed 's|\$PVC'"|$(PVC)|g" | \
-#        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
-#        sed 's|\$POD_NAME'"|$(POD_NAME)|g" | \
-#        kubectl delete -n=$(NAMESPACE) -f -
-#
-#        echo "Delete the pvc"
-#        kubectl delete pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
-#      condition: always()
-#      env:
-#        KUBECONFIG: $(KUBECONFIGFILE)
-#      displayName: 'Delete the temp pod and the pvc'
-#    - script: |
-#        echo "Delete everything"
-#        helm delete --purge $(DEPLOYMENT)
-#      condition: always()
-#      env:
-#        KUBECONFIG: $(KUBECONFIGFILE)
-#      displayName: 'Purge the deployment'
+    - script: |
+        echo "Delete the test job"
+        cat .azurePipeline/k8s_test_job.yaml.tmpl | \
+        sed 's|\$PVC'"|$(PVC)|g" | \
+        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
+        sed 's|\$IMAGE_NAME_WITH_TAG'"|$(IMAGE_NAME_WITH_TAG)|g" | \
+        sed 's|\$SERVICE_IP'"|$(SERVICE_IP)|g" | \
+        kubectl delete -n=$(NAMESPACE) -f -
+      condition: always()
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Delete the test job'
+    - script: |
+        echo "Delete the temp pod"
+        cat .azurePipeline/k8s_get_results.yaml.tmpl | \
+        sed 's|\$PVC'"|$(PVC)|g" | \
+        sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" | \
+        sed 's|\$POD_NAME'"|$(POD_NAME)|g" | \
+        kubectl delete -n=$(NAMESPACE) -f -
+
+        echo "Delete the pvc"
+        kubectl delete pvc -n=$(NAMESPACE) -l deployment=$(DEPLOYMENT)
+      condition: always()
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Delete the temp pod and the pvc'
+    - script: |
+        echo "Delete everything"
+        helm delete --purge $(DEPLOYMENT)
+      condition: always()
+      env:
+        KUBECONFIG: $(KUBECONFIGFILE)
+      displayName: 'Purge the deployment'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ stages:
     # Prepare all the variables required during the scripts.
     - template: .azurePipeline/templateDockerTagFromBranch.yml
     - script: |
-        echo es$(Build.SourceVersion)| head -c 40 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
+        echo es$(Build.SourceVersion)| head -c 10 | xargs -I@ echo "##vso[task.setvariable variable=DEPLOYMENT]@"
       displayName: 'Set some variables part 1'
     - script: |
         echo "##vso[task.setvariable variable=KUBECONFIGFILE]$(DownloadSecureFile.secureFilePath)"

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -1,16 +1,19 @@
 Devops
 ===========
 
-Azure Pipeline
---------------
+Continuous Integration
+----------------------
 
-``entity-service`` is automatically built and tested using Azure Pipeline
+Azure DevOps
+~~~~~~~~~~~~
+
+``anonlink-entity-service`` is automatically built and tested using Azure DevOps
 in the project `Anonlink <https://dev.azure.com/data61/Anonlink>`.
 
 It consists only of a `build pipeline <https://dev.azure.com/data61/Anonlink/_build?definitionId=1>`.
 
-The build pipeline is described by the script `azurePipeline.yml`
-which is using resources from the folder `.azurePipeline`.
+The build pipeline is defined by the script `azurePipeline.yml`
+which uses resources from the folder `.azurePipeline`.
 Mainly, it:
 
 - builds and pushes docker images
@@ -18,18 +21,18 @@ Mainly, it:
   - the backend ``data61/anonlink-app``
   - the tutorials ``data61/anonlink-docs-tutorials`` (used to tests the tutorial Python Notebooks)
   - the benchmark ``data61/anonlink-benchmark`` (used to run the benchmark)
-- runs the benchmark using ``docker-compose`` and publishes the artiafct in Azure
+- runs the benchmark using ``docker-compose`` and publishes the results as an artifact in Azure
 - runs the tutorial tests using ``docker-compose`` and publishes the results in Azure
 - runs the integration tests by deploying the whole service on ``Kubernetes``, runs the tests and publishes the results in Azure.   
 
 The build pipeline is triggered for every push on every branch. It is not triggered by Pull
-Requests not to build twice the same commit.
+Requests to avoid duplicate testing and building potentially untrusted code.
 
 The build pipeline requires two environment variables provided by Azure environment:
 
 - `dockerHubId`: username for the pipeline to push images to Data61 dockerhub
 - `dockerHubPassword`: password for the corresponding username (this is a secret variable).
 
-It also requires a secret file (given in the Azure `Library` tab) containing the ``aws`` cluster
+It also requires a secret file (given in the Azure `Library` tab) containing the ``k8s`` cluster
 configuration used by ``kubectl``.
 

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -2,7 +2,7 @@ Devops
 ===========
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    index
    
@@ -18,21 +18,23 @@ It consists only of a `build pipeline <https://dev.azure.com/data61/Anonlink/_bu
 The build pipeline is described by the script `azurePipeline.yml`
 which is using resources from the folder `.azurePipeline`.
 Mainly, it:
- - builds and pushes docker images
-   - the frontend ``data61/anonlink-nginx``
-   - the backend ``data61/anonlink-app``
-   - the tutorials ``data61/anonlink-docs-tutorials`` (used to tests the tutorial Python Notebooks)
-   - the benchmark ``data61/anonlink-benchmark`` (used to run the benchmark)
- - runs the benchmark using ``docker-compose`` and publishes the artiafct in Azure
- - runs the tutorial tests using ``docker-compose`` and publishes the results in Azure
- - runs the integration tests by deploying the whole service on ``Kubernetes``, runs the tests and publishes the results in Azure.   
+
+- builds and pushes docker images
+  - the frontend ``data61/anonlink-nginx``
+  - the backend ``data61/anonlink-app``
+  - the tutorials ``data61/anonlink-docs-tutorials`` (used to tests the tutorial Python Notebooks)
+  - the benchmark ``data61/anonlink-benchmark`` (used to run the benchmark)
+- runs the benchmark using ``docker-compose`` and publishes the artiafct in Azure
+- runs the tutorial tests using ``docker-compose`` and publishes the results in Azure
+- runs the integration tests by deploying the whole service on ``Kubernetes``, runs the tests and publishes the results in Azure.   
 
 The build pipeline is triggered for every push on every branch. It is not triggered by Pull
 Requests not to build twice the same commit.
 
 The build pipeline requires two environment variables provided by Azure environment:
- - `dockerHubId`: username for the pipeline to push images to Data61 dockerhub
- - `dockerHubPassword`: password for the corresponding username (this is a secret variable).
+
+- `dockerHubId`: username for the pipeline to push images to Data61 dockerhub
+- `dockerHubPassword`: password for the corresponding username (this is a secret variable).
 
 It also requires a secret file (given in the Azure `Library` tab) containing the ``aws`` cluster
 configuration used by ``kubectl``.

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -1,12 +1,6 @@
 Devops
 ===========
 
-.. toctree::
-   :maxdepth: 2
-
-   index
-   
-
 Azure Pipeline
 --------------
 

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -1,0 +1,39 @@
+Devops
+===========
+
+.. toctree::
+   :maxdepth: 1
+
+   index
+   
+
+Azure Pipeline
+--------------
+
+``entity-service`` is automatically built and tested using Azure Pipeline
+in the project `Anonlink <https://dev.azure.com/data61/Anonlink>`.
+
+It consists only of a `build pipeline <https://dev.azure.com/data61/Anonlink/_build?definitionId=1>`.
+
+The build pipeline is described by the script `azurePipeline.yml`
+which is using resources from the folder `.azurePipeline`.
+Mainly, it:
+ - builds and pushes docker images
+   - the frontend ``data61/anonlink-nginx``
+   - the backend ``data61/anonlink-app``
+   - the tutorials ``data61/anonlink-docs-tutorials`` (used to tests the tutorial Python Notebooks)
+   - the benchmark ``data61/anonlink-benchmark`` (used to run the benchmark)
+ - runs the benchmark using ``docker-compose`` and publishes the artiafct in Azure
+ - runs the tutorial tests using ``docker-compose`` and publishes the results in Azure
+ - runs the integration tests by deploying the whole service on ``Kubernetes``, runs the tests and publishes the results in Azure.   
+
+The build pipeline is triggered for every push on every branch. It is not triggered by Pull
+Requests not to build twice the same commit.
+
+The build pipeline requires two environment variables provided by Azure environment:
+ - `dockerHubId`: username for the pipeline to push images to Data61 dockerhub
+ - `dockerHubPassword`: password for the corresponding username (this is a secret variable).
+
+It also requires a secret file (given in the Azure `Library` tab) containing the ``aws`` cluster
+configuration used by ``kubectl``.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,5 +55,6 @@ Table Of Contents
    security
    deployment
    development
+   devops
    benchmarking
    logging


### PR DESCRIPTION
That was quite painful, but it is finally working end to end!!!
The integration step using docker compose has been removed to run these tests only using kubernetes.
We were otherwise running twice the same tests on different deployment.
With this pipeline, we are still testing the docker compose and the kubernetes deployment, but running different tests on each.
On the docker compose deployment, we run the benchmark and the tutorial tests.
On k8s, we run the integration tests. 
It was preferred as the integration tests are BIG, and takes a long time, so it is better t use some beefy infrastructure instead of a single small VM running the whole service (which was tricky because of timeouts).

Note: this is **not** deploying a release, which is out of scope for this work.
Note 2: this is to update the PR #388 removing the integration tests and running them in k8s only.