### PR TITLE
Update alpine to 3.10

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10.1
 
 EXPOSE 8000
 ADD requirements.txt /var/www/requirements.txt
@@ -18,7 +18,7 @@ RUN apk add --no-cache python3 libstdc++ mpc1-dev yajl libpq && \
     pip3 install --upgrade -r requirements.txt && \
     apk del --no-cache .build-deps && \
     rm -fr /tmp/* /var/cache/apk/* /root/.cache/pip
-    
+
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 anonlink==0.11.2
 bitmath==1.3.1.2
-celery==4.2.1
-clkhash==0.12.0
+celery==4.3.0
+clkhash==0.14.0
 colorama==0.4.1 # required for structlog
 connexion==1.4
 Flask-Opentracing==0.2.0


### PR DESCRIPTION
A package I've not heard of, that we don't directly use has a xml parsing vulnerability.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843

This PR updates our base alpine image to remove the vulnerability and updates celery to a compatible version.