### PR TITLE
Feature connection pools

### DIFF
--- a/backend/entityservice/__init__.py
+++ b/backend/entityservice/__init__.py
@@ -48,6 +48,11 @@ def initdb_command():
     print('Initialised the database.')
 
 
+@app.before_first_request
+def before_first_request():
+    db.init_db_pool()
+
+
 @app.before_request
 def before_request():
     g.log = logger.new(request=str(uuid.uuid4())[:8])
@@ -59,17 +64,6 @@ def before_request():
                 headers[header] = request.headers[header]
         g.log.bind(**headers)
     g.flask_tracer = flask_tracer
-
-
-@app.teardown_appcontext
-def close_db(error):
-    db = g.pop('db', None)
-
-    if db is not None:
-        g.log.debug("Closing database connection")
-        for notice in db.notices:
-            g.log.debug(notice)
-        db.close()
 
 
 if __name__ == '__main__':

--- a/backend/entityservice/cache.py
+++ b/backend/entityservice/cache.py
@@ -60,19 +60,18 @@ def get_deserialized_filter(dp_id):
     else:
         logger.debug("Looking up popcounts and filename from database")
         with DBConn() as db:
-            #db = database.connect_db()
-            mc = connect_to_object_store()
             serialized_filters_file = database.get_filter_metadata(db, dp_id)
 
-            logger.debug("Getting filters from object store")
+        mc = connect_to_object_store()
+        logger.debug("Getting filters from object store")
 
-            # Note this uses already calculated popcounts unlike
-            # serialization.deserialize_filters()
-            raw_data_response = mc.get_object(config.MINIO_BUCKET, serialized_filters_file)
-            python_filters = serialization.binary_unpack_filters(raw_data_response)
+        # Note this uses already calculated popcounts unlike
+        # serialization.deserialize_filters()
+        raw_data_response = mc.get_object(config.MINIO_BUCKET, serialized_filters_file)
+        python_filters = serialization.binary_unpack_filters(raw_data_response)
 
-            set_deserialized_filter(dp_id, python_filters)
-            return python_filters
+        set_deserialized_filter(dp_id, python_filters)
+        return python_filters
 
 
 def remove_from_cache(dp_id):

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -33,6 +33,7 @@ def init_db(delay=0.5):
 
     @param float delay: Number of seconds to wait before executing the SQL.
     """
+    init_db_pool()
     time.sleep(delay)
     with DBConn() as db:
         with current_app.open_resource('init-db-schema.sql', mode='r') as f:
@@ -86,7 +87,7 @@ class DBConn:
     def __init__(self):
         if connection_pool is None:
             raise ValueError("The database connection pool has not been initialized by the application."
-                                  " Use 'init_db_pool()' to initialise it.")
+                             " Use 'init_db_pool()' to initialise it.")
 
         logger.debug("Get a database connection from the pool.")
         try:

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -51,7 +51,7 @@ def init_db_pool():
     if connection_pool is None:
         logger.info("Initialize the database connection pool.", database=db, user=user, password=pw, host=host)
         try:
-            connection_pool = ThreadedConnectionPool(0, db_max_connections, database=db, user=user, password=pw, host=host)
+            connection_pool = ThreadedConnectionPool(1, db_max_connections, database=db, user=user, password=pw, host=host)
         except psycopg2.Error:
             logger.warning("Can't connect to database")
             raise ConnectionError("Issue connecting to database")

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -42,6 +42,9 @@ def init_db(delay=0.5):
 
 
 def init_db_pool():
+    """
+    Initializes the database connection pool required by the application to connect to the database.
+    """
     db = config.DATABASE
     host = config.DATABASE_SERVER
     user = config.DATABASE_USER

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -52,9 +52,9 @@ def init_db_pool():
         logger.info("Initialize the database connection pool.", database=db, user=user, password=pw, host=host)
         try:
             connection_pool = ThreadedConnectionPool(1, db_max_connections, database=db, user=user, password=pw, host=host)
-        except psycopg2.Error:
+        except psycopg2.Error as e:
             logger.warning("Can't connect to database")
-            raise ConnectionError("Issue connecting to database")
+            raise ConnectionError("Issue connecting to database") from e
     else:
         logger.warning("The connection pool has already been initialized.")
 

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -45,13 +45,14 @@ def init_db_pool():
     host = config.DATABASE_SERVER
     user = config.DATABASE_USER
     pw = config.DATABASE_PASSWORD
+    db_min_connections = config.DATABASE_MIN_CONNECTIONS
     db_max_connections = config.DATABASE_MAX_CONNECTIONS
 
     global connection_pool
     if connection_pool is None:
         logger.info("Initialize the database connection pool.", database=db, user=user, password=pw, host=host)
         try:
-            connection_pool = ThreadedConnectionPool(1, db_max_connections, database=db, user=user, password=pw, host=host)
+            connection_pool = ThreadedConnectionPool(db_min_connections, db_max_connections, database=db, user=user, password=pw, host=host)
         except psycopg2.Error as e:
             logger.warning("Can't connect to database")
             raise ConnectionError("Issue connecting to database") from e

--- a/backend/entityservice/models/run.py
+++ b/backend/entityservice/models/run.py
@@ -1,6 +1,7 @@
 from structlog import get_logger
 
 import entityservice.database as db
+from entityservice.database import DBConn
 from entityservice import cache
 from entityservice.settings import Config as config
 from entityservice.utils import generate_code
@@ -64,9 +65,10 @@ class Run(object):
         self.run_id = generate_code()
         logger.info("Created run id", rid=self.run_id)
 
-        self.type = 'no_mapping' \
-            if db.get_project_column(db.get_db(), project_id, 'result_type') == 'similarity_scores' \
-            else 'default'
+        with DBConn() as conn:
+            self.type = 'no_mapping' \
+                if db.get_project_column(conn, project_id, 'result_type') == 'similarity_scores' \
+                else 'default'
 
     @staticmethod
     def from_json(data, project_id):

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -33,7 +33,8 @@ class Config(object):
     DATABASE = os.getenv('DATABASE', 'postgres')
     DATABASE_USER = os.getenv('DATABASE_USER', 'postgres')
     DATABASE_PASSWORD = os.getenv('DATABASE_PASSWORD', '')
-    DATABASE_MAX_CONNECTIONS = os.getenv('DATABASE_MAX_CONNECTIONS', '1')
+    DATABASE_MIN_CONNECTIONS = os.getenv('DATABASE_MIN_CONNECTIONS', '1')
+    DATABASE_MAX_CONNECTIONS = os.getenv('DATABASE_MAX_CONNECTIONS', '3')
 
     CELERY_BROKER_URL = os.getenv(
         'CELERY_BROKER_URL',

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -33,6 +33,7 @@ class Config(object):
     DATABASE = os.getenv('DATABASE', 'postgres')
     DATABASE_USER = os.getenv('DATABASE_USER', 'postgres')
     DATABASE_PASSWORD = os.getenv('DATABASE_PASSWORD', '')
+    DATABASE_MAX_CONNECTIONS = os.getenv('DATABASE_MAX_CONNECTIONS', '5')
 
     CELERY_BROKER_URL = os.getenv(
         'CELERY_BROKER_URL',

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -33,7 +33,7 @@ class Config(object):
     DATABASE = os.getenv('DATABASE', 'postgres')
     DATABASE_USER = os.getenv('DATABASE_USER', 'postgres')
     DATABASE_PASSWORD = os.getenv('DATABASE_PASSWORD', '')
-    DATABASE_MAX_CONNECTIONS = os.getenv('DATABASE_MAX_CONNECTIONS', '5')
+    DATABASE_MAX_CONNECTIONS = os.getenv('DATABASE_MAX_CONNECTIONS', '1')
 
     CELERY_BROKER_URL = os.getenv(
         'CELERY_BROKER_URL',

--- a/backend/entityservice/tasks/project_cleanup.py
+++ b/backend/entityservice/tasks/project_cleanup.py
@@ -19,14 +19,14 @@ def remove_project(project_id):
     log.debug("Remove all project resources")
 
     with DBConn() as conn:
-        #conn = db.connect_db()
         log.debug("Deleting project resourced from database")
         db.delete_project_data(conn, project_id)
         log.debug("Getting object store files associated with project from database")
         object_store_files = db.get_all_objects_for_project(conn, project_id)
-        log.debug(f"Removing {len(object_store_files)} object store files associated with project.")
-        delete_minio_objects.delay(object_store_files, project_id)
-        log.info("Project resources removed")
+        
+    log.debug(f"Removing {len(object_store_files)} object store files associated with project.")
+    delete_minio_objects.delay(object_store_files, project_id)
+    log.info("Project resources removed")
 
 
 @celery.task(base=TracedTask,

--- a/backend/entityservice/tasks/project_cleanup.py
+++ b/backend/entityservice/tasks/project_cleanup.py
@@ -1,6 +1,7 @@
 from minio.error import MinioError
 
 import entityservice.database as db
+from entityservice.database import DBConn
 from entityservice.object_store import connect_to_object_store
 from entityservice.async_worker import celery, logger
 from entityservice.tasks.base_task import TracedTask
@@ -17,14 +18,15 @@ def remove_project(project_id):
     log = logger.bind(pid=project_id)
     log.debug("Remove all project resources")
 
-    conn = db.connect_db()
-    log.debug("Deleting project resourced from database")
-    db.delete_project_data(conn, project_id)
-    log.debug("Getting object store files associated with project from database")
-    object_store_files = db.get_all_objects_for_project(conn, project_id)
-    log.debug(f"Removing {len(object_store_files)} object store files associated with project.")
-    delete_minio_objects.delay(object_store_files, project_id)
-    log.info("Project resources removed")
+    with DBConn() as conn:
+        #conn = db.connect_db()
+        log.debug("Deleting project resourced from database")
+        db.delete_project_data(conn, project_id)
+        log.debug("Getting object store files associated with project from database")
+        object_store_files = db.get_all_objects_for_project(conn, project_id)
+        log.debug(f"Removing {len(object_store_files)} object store files associated with project.")
+        delete_minio_objects.delay(object_store_files, project_id)
+        log.info("Project resources removed")
 
 
 @celery.task(base=TracedTask,

--- a/backend/entityservice/tasks/stats.py
+++ b/backend/entityservice/tasks/stats.py
@@ -1,37 +1,38 @@
 from datetime import timedelta
 
 from entityservice.async_worker import celery, logger
-from entityservice.database import connect_db, get_elapsed_run_times
+from entityservice.database import DBConn, get_elapsed_run_times
 from entityservice.database import get_total_comparisons_for_project
 from entityservice.database import insert_comparison_rate
 
 
 @celery.task(ignore_result=True)
 def calculate_comparison_rate():
-    dbinstance = connect_db()
-    logger.info("Calculating global comparison rate")
+    with DBConn() as dbinstance:
+        #dbinstance = connect_db()
+        logger.info("Calculating global comparison rate")
 
-    total_comparisons = 0
-    total_time = timedelta(0)
-    for run in get_elapsed_run_times(dbinstance):
+        total_comparisons = 0
+        total_time = timedelta(0)
+        for run in get_elapsed_run_times(dbinstance):
 
-        comparisons = get_total_comparisons_for_project(dbinstance, run['project_id'])
+            comparisons = get_total_comparisons_for_project(dbinstance, run['project_id'])
 
-        if comparisons != 'NA':
-            total_comparisons += comparisons
+            if comparisons != 'NA':
+                total_comparisons += comparisons
+            else:
+                logger.debug("Skipping run as it hasn't completed")
+            total_time += run['elapsed']
+
+        if total_time.total_seconds() > 0:
+            rate = total_comparisons/total_time.total_seconds()
+            logger.info("Total comparisons: {}".format(total_comparisons))
+            logger.info("Total time:        {}".format(total_time.total_seconds()))
+            logger.info("Comparison rate:   {}".format(rate))
+
+            with dbinstance.cursor() as cur:
+                insert_comparison_rate(cur, rate)
+
+            dbinstance.commit()
         else:
-            logger.debug("Skipping run as it hasn't completed")
-        total_time += run['elapsed']
-
-    if total_time.total_seconds() > 0:
-        rate = total_comparisons/total_time.total_seconds()
-        logger.info("Total comparisons: {}".format(total_comparisons))
-        logger.info("Total time:        {}".format(total_time.total_seconds()))
-        logger.info("Comparison rate:   {}".format(rate))
-
-        with dbinstance.cursor() as cur:
-            insert_comparison_rate(cur, rate)
-
-        dbinstance.commit()
-    else:
-        logger.warning("Can't compute comparison rate yet")
+            logger.warning("Can't compute comparison rate yet")

--- a/backend/entityservice/tasks/stats.py
+++ b/backend/entityservice/tasks/stats.py
@@ -9,7 +9,6 @@ from entityservice.database import insert_comparison_rate
 @celery.task(ignore_result=True)
 def calculate_comparison_rate():
     with DBConn() as dbinstance:
-        #dbinstance = connect_db()
         logger.info("Calculating global comparison rate")
 
         total_comparisons = 0

--- a/backend/entityservice/tasks/stats.py
+++ b/backend/entityservice/tasks/stats.py
@@ -32,6 +32,5 @@ def calculate_comparison_rate():
             with dbinstance.cursor() as cur:
                 insert_comparison_rate(cur, rate)
 
-            dbinstance.commit()
         else:
             logger.warning("Can't compute comparison rate yet")

--- a/backend/entityservice/utils.py
+++ b/backend/entityservice/utils.py
@@ -12,8 +12,7 @@ from flask import request
 from connexion import ProblemException
 from structlog import get_logger
 
-from entityservice.database import connect_db, get_number_parties_uploaded, get_number_parties_ready
-from entityservice.database import get_project_column
+from entityservice.database import DBConn, get_number_parties_uploaded, get_number_parties_ready, get_project_column
 
 logger = get_logger()
 
@@ -126,16 +125,16 @@ def clks_uploaded_to_project(project_id, check_data_ready=False):
     """ See if the given project has had all parties contribute data.
     """
     logger.info("Counting contributing parties")
-    conn = connect_db()
-    if check_data_ready:
-        parties_contributed = get_number_parties_ready(conn, project_id)
-        logger.info("Parties where data is ready: {}".format(parties_contributed))
-    else:
-        parties_contributed = get_number_parties_uploaded(conn, project_id)
-        logger.info("Parties where data is uploaded: {}".format(parties_contributed))
-    number_parties = get_project_column(conn, project_id, 'parties')
-    logger.info("{}/{} parties have contributed clks".format(parties_contributed, number_parties))
-    return parties_contributed == number_parties
+    with DBConn() as conn:
+        if check_data_ready:
+            parties_contributed = get_number_parties_ready(conn, project_id)
+            logger.info("Parties where data is ready: {}".format(parties_contributed))
+        else:
+            parties_contributed = get_number_parties_uploaded(conn, project_id)
+            logger.info("Parties where data is uploaded: {}".format(parties_contributed))
+        number_parties = get_project_column(conn, project_id, 'parties')
+        logger.info("{}/{} parties have contributed clks".format(parties_contributed, number_parties))
+        return parties_contributed == number_parties
 
 
 def similarity_matrix_from_csv_bytes(data):

--- a/backend/entityservice/utils.py
+++ b/backend/entityservice/utils.py
@@ -133,8 +133,8 @@ def clks_uploaded_to_project(project_id, check_data_ready=False):
             parties_contributed = get_number_parties_uploaded(conn, project_id)
             logger.info("Parties where data is uploaded: {}".format(parties_contributed))
         number_parties = get_project_column(conn, project_id, 'parties')
-        logger.info("{}/{} parties have contributed clks".format(parties_contributed, number_parties))
-        return parties_contributed == number_parties
+    logger.info("{}/{} parties have contributed clks".format(parties_contributed, number_parties))
+    return parties_contributed == number_parties
 
 
 def similarity_matrix_from_csv_bytes(data):

--- a/backend/entityservice/views/auth_checks.py
+++ b/backend/entityservice/views/auth_checks.py
@@ -11,8 +11,8 @@ logger = get_logger()
 def abort_if_project_in_error_state(project_id):
     with DBConn() as conn:
         num_parties_with_error = db.get_encoding_error_count(conn, project_id)
-        if num_parties_with_error > 0:
-            safe_fail_request(500, message="Can't post run as project has errors")
+    if num_parties_with_error > 0:
+        safe_fail_request(500, message="Can't post run as project has errors")
 
 
 def abort_if_project_doesnt_exist(project_id):

--- a/backend/entityservice/views/auth_checks.py
+++ b/backend/entityservice/views/auth_checks.py
@@ -1,7 +1,7 @@
 from structlog import get_logger
 
 from entityservice import database as db
-from entityservice.database import get_db, get_project_column
+from entityservice.database import get_project_column, DBConn
 from entityservice.messages import INVALID_ACCESS_MSG
 from entityservice.utils import safe_fail_request
 
@@ -9,22 +9,23 @@ logger = get_logger()
 
 
 def abort_if_project_in_error_state(project_id):
-    conn = get_db()
-    num_parties_with_error = db.get_encoding_error_count(conn, project_id)
-    if num_parties_with_error > 0:
-        safe_fail_request(500, message="Can't post run as project has errors")
+    with DBConn() as conn:
+        num_parties_with_error = db.get_encoding_error_count(conn, project_id)
+        if num_parties_with_error > 0:
+            safe_fail_request(500, message="Can't post run as project has errors")
 
 
 def abort_if_project_doesnt_exist(project_id):
-    conn = get_db()
-    resource_exists = db.check_project_exists(conn, project_id)
+    with DBConn() as conn:
+        resource_exists = db.check_project_exists(conn, project_id)
     if not resource_exists:
         logger.info("Requested project resource with invalid identifier token")
         safe_fail_request(403, message=INVALID_ACCESS_MSG)
 
 
 def abort_if_run_doesnt_exist(project_id, run_id):
-    resource_exists = db.check_run_exists(get_db(), project_id, run_id)
+    with DBConn() as conn:
+        resource_exists = db.check_run_exists(conn, project_id, run_id)
     if not resource_exists:
         logger.info("Requested project or run resource with invalid identifier token")
         safe_fail_request(403, message=INVALID_ACCESS_MSG)
@@ -32,20 +33,23 @@ def abort_if_run_doesnt_exist(project_id, run_id):
 
 def abort_if_invalid_dataprovider_token(update_token):
     logger.debug("checking authorization token to update data")
-    resource_exists = db.check_update_auth(get_db(), update_token)
+    with DBConn() as conn:
+        resource_exists = db.check_update_auth(conn, update_token)
     if not resource_exists:
         safe_fail_request(403, message=INVALID_ACCESS_MSG)
 
 
 def is_results_token_valid(project_id, results_token):
-    return db.check_project_auth(get_db(), project_id, results_token)
+    with DBConn() as conn:
+        return db.check_project_auth(conn, project_id, results_token)
 
 
 def is_receipt_token_valid(resource_id, receipt_token):
-    if db.select_dataprovider_id(get_db(), resource_id, receipt_token) is None:
-        return False
-    else:
-        return True
+    with DBConn() as conn:
+        if db.select_dataprovider_id(conn, resource_id, receipt_token) is None:
+            return False
+        else:
+            return True
 
 
 def abort_if_invalid_results_token(resource_id, results_token):
@@ -60,7 +64,8 @@ def dataprovider_id_if_authorize(resource_id, receipt_token):
     if not is_receipt_token_valid(resource_id, receipt_token):
         safe_fail_request(403, message=INVALID_ACCESS_MSG)
 
-    dp_id = db.select_dataprovider_id(get_db(), resource_id, receipt_token)
+    with DBConn() as conn:
+        dp_id = db.select_dataprovider_id(conn, resource_id, receipt_token)
     return dp_id
 
 
@@ -83,7 +88,8 @@ def get_authorization_token_type_or_abort(project_id, token):
 
     # Note that at this stage we have EITHER a receipt or result token, and depending on the result_type
     # that might mean the caller is not authorized.
-    result_type = get_project_column(get_db(), project_id, 'result_type')
+    with DBConn() as conn:
+        result_type = get_project_column(conn, project_id, 'result_type')
     if result_type in {'mapping', 'similarity_scores'} and token_type == 'receipt_token':
         logger.info("Caller provided receipt token to get results")
         safe_fail_request(403, message=INVALID_ACCESS_MSG)

--- a/backend/entityservice/views/general.py
+++ b/backend/entityservice/views/general.py
@@ -14,13 +14,12 @@ def status_get():
 
     if status is None:
         # We ensure we can connect to the database during the status check
-        db1 = db.get_db()
+        with db.DBConn() as conn:
+            number_of_mappings = db.query_db(conn, '''
+                        SELECT COUNT(*) FROM projects
+                        ''', one=True)['count']
 
-        number_of_mappings = db.query_db(db1, '''
-                    SELECT COUNT(*) FROM projects
-                    ''', one=True)['count']
-
-        current_rate = db.get_latest_rate(db1)
+            current_rate = db.get_latest_rate(conn)
 
         status = {
             'status': 'ok',

--- a/backend/entityservice/views/run/description.py
+++ b/backend/entityservice/views/run/description.py
@@ -18,9 +18,8 @@ def get(project_id, run_id):
     abort_if_invalid_results_token(project_id, request.headers.get('Authorization'))
 
     log.info("request for run description authorized")
-
-    db_conn = db.get_db()
-    run_object = db.get_run(db_conn, run_id)
+    with db.DBConn() as conn:
+        run_object = db.get_run(conn, run_id)
 
     return RunDescription().dump(run_object)
 

--- a/backend/entityservice/views/run/results.py
+++ b/backend/entityservice/views/run/results.py
@@ -5,7 +5,7 @@ import opentracing
 from entityservice import database as db
 from entityservice.serialization import get_similarity_scores
 from entityservice.utils import safe_fail_request
-from entityservice.views.auth_checks import abort_if_run_doesnt_exist, get_authorization_token_type_or_abort, abort_if_invalid_results_token
+from entityservice.views.auth_checks import abort_if_run_doesnt_exist, get_authorization_token_type_or_abort
 
 logger = get_logger()
 
@@ -20,20 +20,19 @@ def get(project_id, run_id):
         # Check the caller has a valid results token.
         token = request.headers.get('Authorization')
         log.info("request to access run result authorized")
+    with db.DBConn() as conn:
+        with opentracing.tracer.start_span('get-run-state', child_of=parent_span) as span:
+            state = db.get_run_state(conn, run_id)
+            log.info("run state is '{}'".format(state))
 
-    with opentracing.tracer.start_span('get-run-state', child_of=parent_span) as span:
-        dbinstance = db.get_db()
-        state = db.get_run_state(dbinstance, run_id)
-        log.info("run state is '{}'".format(state))
-
-    # Check that the run is not in a terminal state, otherwise 404
-    if state == 'completed':
-        with opentracing.tracer.start_span('get-run-result', child_of=parent_span) as span:
-            return get_result(dbinstance, project_id, run_id, token)
-    elif state == 'error':
-        safe_fail_request(500, message='Error during computation of run')
-    else:
-        safe_fail_request(404, message='run is not complete')
+        # Check that the run is not in a terminal state, otherwise 404
+        if state == 'completed':
+            with opentracing.tracer.start_span('get-run-result', child_of=parent_span) as span:
+                return get_result(conn, project_id, run_id, token)
+        elif state == 'error':
+            safe_fail_request(500, message='Error during computation of run')
+        else:
+            safe_fail_request(404, message='run is not complete')
 
 
 def get_result(dbinstance, project_id, run_id, token):

--- a/backend/entityservice/views/run/status.py
+++ b/backend/entityservice/views/run/status.py
@@ -2,10 +2,8 @@ from flask import request, g
 from structlog import get_logger
 import opentracing
 
-from entityservice import app, database as db, cache as cache
-from entityservice.database import get_db
-from entityservice.views.auth_checks import abort_if_run_doesnt_exist, abort_if_invalid_results_token, \
-    get_authorization_token_type_or_abort
+from entityservice import database as db, cache as cache
+from entityservice.views.auth_checks import abort_if_run_doesnt_exist, get_authorization_token_type_or_abort
 from entityservice.views.serialization import completed, running, error
 from entityservice.models.run import RUN_TYPES
 
@@ -25,9 +23,9 @@ def get(project_id, run_id):
         log.debug("Run status authorized using {} token".format(auth_token_type))
 
     with opentracing.tracer.start_span('get-status-from-db', child_of=parent_span) as span:
-        dbinstance = get_db()
-        run_status = db.get_run_status(dbinstance, run_id)
-        project_in_error = db.get_encoding_error_count(dbinstance, project_id) > 0
+        with db.DBConn() as conn:
+            run_status = db.get_run_status(conn, run_id)
+            project_in_error = db.get_encoding_error_count(conn, project_id) > 0
         span.set_tag('stage', run_status['stage'])
 
     run_type = RUN_TYPES[run_status['type']]
@@ -45,13 +43,15 @@ def get(project_id, run_id):
     # trying to get progress if available
     if stage == 1:
         # waiting for CLKs
-        abs_val = db.get_number_parties_uploaded(dbinstance, project_id)
-        max_val = db.get_project_column(dbinstance, project_id, 'parties')
+        with db.DBConn() as conn:
+            abs_val = db.get_number_parties_uploaded(conn, project_id)
+            max_val = db.get_project_column(conn, project_id, 'parties')
     elif stage == 2:
         # Computing similarity
         abs_val = cache.get_progress(run_id)
         if abs_val is not None:
-            max_val = db.get_total_comparisons_for_project(dbinstance, project_id)
+            with db.DBConn() as conn:
+                max_val = db.get_total_comparisons_for_project(conn, project_id)
     else:
         # Solving for mapping (no progress)
         abs_val = None


### PR DESCRIPTION
Simplify the access to dabases to a single way:
```
with DBConn() as conn:
  ...
```
It will under the hood handle how to get a connection: either using a connection pool if available, or creating a single use connection.

The two main entry points which behave differently are due to the application having different entry points: mainly one for celery and one for flask.
Each behaves quite differently (yeah...)
But with these changes a dev will not have to worry from where the method is called.

The PR may also look bigger than what it is: I removed some method to create databases connections, to use the single way, which was repeated on a number of files.