### PR TITLE
Benchmark repeat parameter and results pushed to s3

### DIFF
--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -272,6 +272,7 @@ def run_single_experiment(server, config, threshold, size_a, size_b, experiment)
     result = {}
     credentials = {}
     run = {}
+    logger.info("Starting time: {}".format(time.asctime()))
     try:
         credentials = rest_client.project_create(server, config['schema'], 'mapping',
                                                  "benchy_{}".format(experiment))
@@ -305,6 +306,7 @@ def run_single_experiment(server, config, threshold, size_a, size_b, experiment)
         logger.info('cleaning up...')
         delete_resources(config, credentials, run)
 
+    logger.info("Ending time: {}".format(time.asctime()))
     return result
 
 

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -298,7 +298,8 @@ def push_result_s3(experiment_file):
         aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY')
     )
     s3_bucket = "anonlink-benchmark-result"
-    client.upload_file(experiment_file, s3_bucket, "results.json")
+    s3_file_name = "benchmark_results-{}.json".format(time.strftime("%Y%m%d-%H%M%S"))
+    client.upload_file(experiment_file, s3_bucket, s3_file_name)
 
 
 def main():

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -49,6 +49,10 @@ def load_experiments(filepath):
     with open(filepath, 'rt') as f:
         experiments = json.load(f)
 
+    for experiment in experiments:
+        if 'repetition' not in experiment:
+            experiment['repetition'] = 1
+
     jsonschema.validate(experiments, experiment_schema)
 
     return experiments

--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -1,6 +1,7 @@
+arrow
+boto3
 clkhash==0.14.0
+jsonschema
 numpy
 pandas
-arrow
 requests
-jsonschema

--- a/benchmarking/schema/experiments.json
+++ b/benchmarking/schema/experiments.json
@@ -34,6 +34,17 @@
         "examples": [
           0.80, 0.9, 0.95
         ]
+      },
+      "repetition": {
+        "$id": "#/items/properties/repetition",
+        "type": "number",
+        "title": "Number of times this experiment is repeated",
+        "default": 1,
+        "minimum": 1,
+        "multipleOf": 1,
+        "examples": [
+          1, 2, 10, 100
+        ]
       }
     }
   }

--- a/deployment/jobs/benchmark/timing-test-job.yaml
+++ b/deployment/jobs/benchmark/timing-test-job.yaml
@@ -35,16 +35,16 @@ spec:
             value: "/cache/schema.json"
           - name: RESULTS_PATH
             value: "/tmp/results.json"
-          - name: AWS_ACCESS_KEY_ID
+          - name: OBJECT_STORE_ACCESS_KEY
             valueFrom:
               secretKeyRef:
                 name: anonlink-benchmark-aws-credentials
-                key: AWS_ACCESS_KEY_ID
-          - name: AWS_SECRET_ACCESS_KEY
+                key: OBJECT_STORE_ACCESS_KEY
+          - name: OBJECT_STORE_SECRET_KEY
             valueFrom:
               secretKeyRef:
                 name: anonlink-benchmark-aws-credentials
-                key: AWS_SECRET_ACCESS_KEY
+                key: OBJECT_STORE_SECRET_KEY
         volumeMounts:
           - name: experiments-volume
             mountPath: /config

--- a/deployment/jobs/benchmark/timing-test-job.yaml
+++ b/deployment/jobs/benchmark/timing-test-job.yaml
@@ -21,7 +21,7 @@ spec:
           mountPath: /cache
       containers:
       - name: entitytester
-        image: data61/anonlink-benchmark:v0.3.0-dev
+        image: data61/anonlink-benchmark:featurebenchmarkrepeat
         env:
           - name: SERVER
             value: "https://benchmark.es.data61.xyz"

--- a/deployment/jobs/benchmark/timing-test-job.yaml
+++ b/deployment/jobs/benchmark/timing-test-job.yaml
@@ -21,12 +21,12 @@ spec:
           mountPath: /cache
       containers:
       - name: entitytester
-        image: quay.io/n1analytics/entity-benchmark:v0.2.0
+        image: data61/anonlink-benchmark:v0.3.0-dev
         env:
           - name: SERVER
-            value: "https://testing.es.data61.xyz"
+            value: "https://benchmark.es.data61.xyz"
           - name: TIMEOUT
-            value: "1200"
+            value: "2400"
           - name: EXPERIMENT
             value: "/config/experiments.json"
           - name: DATA_PATH
@@ -34,7 +34,17 @@ spec:
           - name: SCHEMA
             value: "/cache/schema.json"
           - name: RESULTS_PATH
-            value: "/app/results.json"
+            value: "/tmp/results.json"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: anonlink-benchmark-aws-credentials
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: anonlink-benchmark-aws-credentials
+                key: AWS_SECRET_ACCESS_KEY
         volumeMounts:
           - name: experiments-volume
             mountPath: /config


### PR DESCRIPTION
Two main features added at the same time (they could have been split).
Use of boto3 for the benchmark to be able to push the results to s3 instead of relying on k8s volumes which are hard to access afterward.
A parameter `repetition` has been added to an experiment schema to be able to repeat the same experiment a number of time in the same benchmarking k8s job. This should reduce the number of issue we could observe when running 100 times 1M*1M linkage as we were previously repeating the same k8s jobs 100 times, which can have issues with volumes which cannot be shared.