### PR TITLE
Fix exception log

### DIFF
--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -103,8 +103,8 @@ class DBConn:
         return self.conn
 
     def __exit__(self, exc_type, exc_val, traceback):
+        result = True
         try:
-            result = True
             if not exc_type:
                 self.conn.commit()
                 for notice in self.conn.notices:
@@ -117,11 +117,11 @@ class DBConn:
                 # Note if we return True we swallow the exception, False we propagate it
                 result = False
                 self.conn.cancel()
-            return result
         except Exception as e:
             logger.warning("Exception cleaning a connection before closing it or returning it to the pool.", e)
         finally:
             connection_pool.putconn(self.conn, close=False)
+            return result
 
 
 def execute_returning_id(cur, query, args):

--- a/backend/entityservice/database/util.py
+++ b/backend/entityservice/database/util.py
@@ -54,11 +54,11 @@ def init_db_pool():
 
     global connection_pool
     if connection_pool is None:
-        logger.info("Initialize the database connection pool.", database=db, user=user, password=pw, host=host)
+        logger.info("Initialize the database connection pool.")
         try:
             connection_pool = ThreadedConnectionPool(db_min_connections, db_max_connections, database=db, user=user, password=pw, host=host)
         except psycopg2.Error as e:
-            logger.warning("Can't connect to database")
+            logger.warning("Can't connect to database", exc_info=True)
             raise ConnectionError("Issue connecting to database") from e
     else:
         logger.warning("The connection pool has already been initialized.")
@@ -96,7 +96,7 @@ class DBConn:
         try:
             self.conn = connection_pool.getconn()
         except psycopg2.Error as e:
-            logger.warning("Can't connect to database", e)
+            logger.warning("Can't connect to database", exc_info=True)
             raise ConnectionError("Issue connecting to database") from e
 
     def __enter__(self):
@@ -117,8 +117,8 @@ class DBConn:
                 # Note if we return True we swallow the exception, False we propagate it
                 result = False
                 self.conn.cancel()
-        except Exception as e:
-            logger.warning("Exception cleaning a connection before closing it or returning it to the pool.", e)
+        except Exception:
+            logger.warning("Exception cleaning a connection before closing it or returning it to the pool.", exc_info=True)
         finally:
             connection_pool.putconn(self.conn, close=False)
             return result
@@ -128,8 +128,7 @@ def execute_returning_id(cur, query, args):
     try:
         cur.execute(query, args)
     except psycopg2.Error as e:
-        logger.debug("Error running db query")
-        logger.debug(e.diag.message_primary)
+        logger.debug("Error running db query", exc_info=True)
         raise e
     query_result = cur.fetchone()
     if query_result is None:

--- a/backend/entityservice/views/run/results.py
+++ b/backend/entityservice/views/run/results.py
@@ -68,7 +68,7 @@ def get_similarity_score_result(dbinstance, run_id):
         return get_similarity_scores(filename)
 
     except TypeError:
-        logger.warning("Couldn't find the similarity score file")
+        logger.warning("Couldn't find the similarity score file", exc_info=True)
         safe_fail_request(500, "Failed to retrieve similarity scores")
 
 

--- a/backend/entityservice/views/run/results.py
+++ b/backend/entityservice/views/run/results.py
@@ -68,7 +68,7 @@ def get_similarity_score_result(dbinstance, run_id):
         return get_similarity_scores(filename)
 
     except TypeError:
-        logger.warning("Couldn't find the similarity score file", exc_info=True)
+        logger.exception("Couldn't find the similarity score file for the runId %s", run_id)
         safe_fail_request(500, "Failed to retrieve similarity scores")
 
 


### PR DESCRIPTION
To print an exception in a log, the line 
```
logger.warning("Can't connect to database", e)
```
fails raising: "TypeError: not all arguments converted during string formatting"
Instead, as we are mainly printing the exception in a `try except` context, use the param `exc_info=True` to print it.