### PR TITLE
Update redis.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ opentracing_instrumentation==2.4.3
 psycopg2==2.7.5
 pytest==3.5.1
 PyYAML==5.1
-redis==3.2.0
+redis==3.2.1
 requests==2.21.0
 setproctitle==1.1.10 # used by celery to change process name
 structlog==18.2.0


### PR DESCRIPTION
3.2.0 has an issue we are observing. 3.2.1 supposedly fixed it.
So in theory, it should fix #412

After running few times the 1M*1M benchmark, it seems to have solved the issue:
it was observed after 7 or so hours of run, but after 8 hours or so with change, it didn't occur.
And based on https://github.com/andymccurdy/redis-py/issues/1144 it should have fixed it.