### PR TITLE
Feature export metrics

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,9 +34,11 @@ USER user
 ADD . /var/www
 
 # Serve using gunicorn. Ideally this has nginx in front of it!
-CMD gunicorn entityservice:app \
+# Note we only use one process - otherwise our metrics get much
+# more complicated.
+CMD gunicorn entityservice:app_dispatch \
     -n entityservice-web \
-    -w 4 \
+    -w 1 \
     -b 0.0.0.0:8000 \
     --timeout 600 \
     --keep-alive 300 \

--- a/backend/entityservice/metrics.py
+++ b/backend/entityservice/metrics.py
@@ -1,0 +1,21 @@
+"""
+See Issue #42
+
+"""
+from prometheus_client import Gauge
+from prometheus_client.core import Counter, Histogram
+
+
+UPLOAD_REQUEST_LATENCY = Histogram('anonlink_upload_request_latency_seconds', 'CLK upload request latency')
+
+STATUS_REQUEST_LATENCY = Histogram('anonlink_status_request_latency_seconds', 'Status Request Latency')
+STATUS_REQUEST_COUNT = Counter('anonlink_status_counter_total', 'Number of Status Requests')
+
+COMPARISON_RATE_GAUGE = Gauge('anonlink_comparison_rate', 'Max number of comparisons per second')
+PROJECT_COUNT = Gauge('anonlink_mapping_counter_total', 'Number of mappings')
+
+RUN_STATUS_COUNT = Counter(
+    'anonlink_run_status_counter',
+    'Number of status checks on a run',
+    ['run']
+)

--- a/backend/entityservice/tests/test_admin.py
+++ b/backend/entityservice/tests/test_admin.py
@@ -24,3 +24,11 @@ def test_status(record_property):
     assert 'rate' in status_json
     assert 'project_count' in status_json
 
+
+def test_metrics(record_property):
+    response = requests.get(url + '/metrics')
+    assert response.status_code == 200, 'Server status was {}'.format(response.status_code)
+
+    record_property("metrics", response.text)
+
+    print(response.text)

--- a/backend/entityservice/tests/test_deletes.py
+++ b/backend/entityservice/tests/test_deletes.py
@@ -19,7 +19,7 @@ def test_delete_runs_after_creating_run_with_clks(requests, result_type_number_p
 def test_delete_runs_after_completed_run(requests, result_type_number_parties):
     project, run_id = _create_data_linkage_run(requests, result_type_number_parties)
     result_token = project['result_token']
-    wait_for_run_completion(requests, project, run_id, result_token, timeout=30)
+    wait_for_run_completion(requests, project, run_id, result_token, timeout=60)
     delete_run(requests, project['project_id'], run_id, result_token)
     _checks_after_run_deleted(requests, project, run_id)
     delete_run(requests, project['project_id'], run_id, result_token)

--- a/backend/entityservice/views/general.py
+++ b/backend/entityservice/views/general.py
@@ -1,29 +1,40 @@
 import platform
 
+from structlog import get_logger
+
 import anonlink
 
 from entityservice import cache
 import entityservice.database as db
+from entityservice.metrics import STATUS_REQUEST_COUNT, STATUS_REQUEST_LATENCY, COMPARISON_RATE_GAUGE, PROJECT_COUNT
 from entityservice.version import __version__
 
 
+logger = get_logger()
+
+
+@STATUS_REQUEST_LATENCY.time()
 def status_get():
     """Displays the latest mapping statistics"""
 
     status = cache.get_status()
+    STATUS_REQUEST_COUNT.inc()
 
     if status is None:
         # We ensure we can connect to the database during the status check
         with db.DBConn() as conn:
-            number_of_mappings = db.query_db(conn, '''
+            number_of_projects = db.query_db(conn, '''
                         SELECT COUNT(*) FROM projects
                         ''', one=True)['count']
 
             current_rate = db.get_latest_rate(conn)
 
+            COMPARISON_RATE_GAUGE.set(current_rate)
+            PROJECT_COUNT.set(number_of_projects)
+
         status = {
             'status': 'ok',
-            'project_count': number_of_mappings,
+            'project_count': number_of_projects,
             'rate': current_rate
         }
 

--- a/backend/entityservice/views/project.py
+++ b/backend/entityservice/views/project.py
@@ -7,6 +7,7 @@ from structlog import get_logger
 import opentracing
 
 import entityservice.database as db
+from entityservice.metrics import UPLOAD_REQUEST_LATENCY
 from entityservice.tasks import handle_raw_upload, check_for_executable_runs, remove_project
 from entityservice.tracing import serialize_span
 from entityservice.utils import safe_fail_request, get_json, generate_code, get_stream, \
@@ -98,6 +99,7 @@ def project_get(project_id):
     return ProjectDescription().dump(project_object)
 
 
+@UPLOAD_REQUEST_LATENCY.time()
 def project_clks_post(project_id):
     """
     Update a project to provide encoded PII data.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ bitmath==1.3.1.2
 celery==4.3.0
 clkhash==0.14.0
 colorama==0.4.1 # required for structlog
-connexion==1.4
+connexion==1.5.3
 Flask-Opentracing==0.2.0
 Flask==1.0.2
 flower==0.9.2
@@ -15,11 +15,12 @@ marshmallow==3.0.0b10
 minio==4.0.4
 opentracing==1.3.0
 opentracing_instrumentation==2.4.3
+prometheus_client
 psycopg2==2.7.5
 pytest==3.5.1
 PyYAML==5.1
 redis==3.2.1
-requests==2.21.0
+requests==2.22.0
 setproctitle==1.1.10 # used by celery to change process name
 structlog==18.2.0
 tenacity==5.1.1

--- a/deployment/entity-service/templates/api-metrics-service.yaml
+++ b/deployment/entity-service/templates/api-metrics-service.yaml
@@ -2,9 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-
 {{- if .Values.api.metrics.service.annotations }}
+  annotations:
 {{ toYaml .Values.api.metrics.service.annotations | indent 4 }}
 {{- end }}
   labels:

--- a/deployment/entity-service/templates/api-metrics-service.yaml
+++ b/deployment/entity-service/templates/api-metrics-service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.api.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+
+{{- if .Values.api.metrics.service.annotations }}
+{{ toYaml .Values.api.metrics.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "es.release_labels" . | indent 4 }}
+    component: "{{ .Values.api.name }}-metrics"
+{{- if .Values.api.metrics.service.labels }}
+{{ toYaml .Values.api.metrics.service.labels | indent 4 }}
+{{- end }}
+  name: {{ template "api.fullname" . }}-metrics
+spec:
+  ports:
+    - name: http
+      port: 8000
+      protocol: TCP
+      targetPort: "entity-flask"
+  selector:
+    app: {{ template "es.fullname" . }}
+    component: {{ required "api.name must be provided." .Values.api.name | quote }}
+    release: {{ .Release.Name }}
+  type: {{ .Values.api.metrics.service.type }}
+{{- end }}

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -139,7 +139,7 @@ api:
     ## A k8s service exposing application metrics
     service:
       annotations:
-        - prometheus.io/scrape: 'true'
+        prometheus.io/scrape: 'true'
       type: ClusterIP
       #labels: []
 

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -133,6 +133,16 @@ api:
     ## security group.
     loadBalancerSourceRanges: []
 
+  metrics:
+    enabled: true
+
+    ## A k8s service exposing application metrics
+    service:
+      annotations:
+        - prometheus.io/scrape: 'true'
+      type: ClusterIP
+      #labels: []
+
 workers:
   name: "matcher"
 

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -181,6 +181,12 @@ running on then forward the port. For example::
     $kubectl port-forward entityservice-monitor-4045544268-s34zl 8888:8888
 
 
+Prometheus Metrics
+------------------
+
+The flask application exposes metrics for prometheus on `/api/v1/metrics`.
+
+
 Upgrade Deployment with Helm
 ----------------------------
 

--- a/tools/ci.yml
+++ b/tools/ci.yml
@@ -13,7 +13,7 @@ services:
       - redis
       - worker
       - nginx
-      
+
   benchmark:
     image: data61/anonlink-benchmark:${TAG:-latest}
     environment:
@@ -27,7 +27,7 @@ services:
       - worker
       - nginx
     entrypoint: /bin/sh -c "dockerize -wait tcp://nginx:8851/v1/status -timeout 1m python benchmark.py"
-    
+
   tutorials:
     image: data61/anonlink-docs-tutorials:${TAG:-latest}
     environment:

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - db_init
       - redis
 
-
   # The application server can also setup the database
   db_init:
     image: data61/anonlink-app:${TAG:-latest}
@@ -95,6 +94,13 @@ services:
 #    entrypoint: celery flower -A  entityservice.async_worker --basic_auth=n1:paillier --url_prefix=/ --port=8888 -Q celery,compute
 #    ports:
 #      - 8888:8888
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - ${PWD}/prometheus-config.yml:/etc/prometheus/prometheus.yml
 
   jaeger:
     image: jaegertracing/all-in-one:latest

--- a/tools/prometheus-config.yml
+++ b/tools/prometheus-config.yml
@@ -7,7 +7,7 @@ scrape_configs:
   honor_timestamps: true
   scrape_interval: 15s
   scrape_timeout: 10s
-  metrics_path: /metrics
+  metrics_path: /metrics/
   scheme: http
   static_configs:
   - targets:

--- a/tools/prometheus-config.yml
+++ b/tools/prometheus-config.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: anonlink
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - backend:8000


### PR DESCRIPTION
Adds an endpoint to the flask app `/api/v1/metrics/` which exposes prometheus metrics.

Note this PR adds a new restriction that gunicorn only uses 1 process, although it should be possible to overcome this within a single pod - but a different approach is required to support multiple flask app pods (which is a shame).
