### PR TITLE
Slower tests

### DIFF
--- a/backend/entityservice/tests/test_deletes.py
+++ b/backend/entityservice/tests/test_deletes.py
@@ -19,7 +19,7 @@ def test_delete_runs_after_creating_run_with_clks(requests, result_type_number_p
 def test_delete_runs_after_completed_run(requests, result_type_number_parties):
     project, run_id = _create_data_linkage_run(requests, result_type_number_parties)
     result_token = project['result_token']
-    wait_for_run_completion(requests, project, run_id, result_token, timeout=20)
+    wait_for_run_completion(requests, project, run_id, result_token, timeout=30)
     delete_run(requests, project['project_id'], run_id, result_token)
     _checks_after_run_deleted(requests, project, run_id)
     delete_run(requests, project['project_id'], run_id, result_token)

--- a/backend/entityservice/tests/test_project_uploads.py
+++ b/backend/entityservice/tests/test_project_uploads.py
@@ -194,13 +194,19 @@ def test_project_json_data_upload_with_too_large_encoded_size(
         result_type=result_type,
         encoding_size=4096
     )
+    # Just initializing it before the loop.
+    project_description = {'error': False}
+    rep = 0
+    max_rep = 10
+    while not project_description['error'] and rep < max_rep:
+        rep += 1
+        time.sleep(1)
+        project_description = requests.get(
+            url + '/projects/{}'.format(new_project_data['project_id']),
+            headers={'Authorization': new_project_data['result_token']}
+        ).json()
+        assert 'error' in project_description
 
-    time.sleep(5)
-    project_description = requests.get(
-        url + '/projects/{}'.format(new_project_data['project_id']),
-        headers={'Authorization': new_project_data['result_token']}
-    ).json()
-    assert 'error' in project_description
     assert project_description['error']
 
 


### PR DESCRIPTION
Update some tests which were failing.  
This branch is based on `deployment-documentation` which modified the default deployment size.
What surprises me is that the `minimal-values` we were using for the k8s tests were supposedly smaller than the default one on the mentioned branch, but the tests take longer...
