### PR TITLE
Refactor cache progress to use redis hash

### DIFF
--- a/backend/entityservice/cache/helpers.py
+++ b/backend/entityservice/cache/helpers.py
@@ -1,0 +1,3 @@
+def _get_run_hash_key(run_id):
+    key = f'run:{run_id}'
+    return key


### PR DESCRIPTION
This PR builds upon the refactoring in https://github.com/data61/anonlink-entity-service/pull/430 by changing the internal redis data structure used to store the progress from a string to a hash.

This will enable us to store other data such as state in the same redis hash object.