### PR TITLE
Benchmark test on CI runs 3 parties linkage 

### DIFF
--- a/benchmarking/linkage-bench-cache-experiments.json
+++ b/benchmarking/linkage-bench-cache-experiments.json
@@ -2,5 +2,9 @@
   {
     "sizes": ["100K", "100K"],
     "threshold": 0.95
+  },
+  {
+    "sizes": ["10K", "10K", "10K"],
+    "threshold": 0.8
   }
 ]

--- a/benchmarking/linkage-bench-cache-experiments.json
+++ b/benchmarking/linkage-bench-cache-experiments.json
@@ -1,7 +1,7 @@
 [
   {
     "sizes": ["100K", "100K"],
-    "threshold": 0.95
+    "threshold": 0.8
   },
   {
     "sizes": ["10K", "10K", "10K"],


### PR DESCRIPTION
Threshold 0.8 is chosen for the 3 party case because the results were quite good.