### PR TITLE
backoffLimit for the test job set to 0.

### DIFF
--- a/.azurePipeline/k8s_test_job.yaml.tmpl
+++ b/.azurePipeline/k8s_test_job.yaml.tmpl
@@ -8,6 +8,7 @@ metadata:
 spec:
   completions: 1
   parallelism: 1
+  backoffLimit: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Otherwise, thed efault value is 6, which means that the job restarts up to 6 time a pod if the previous one failed.