### PR TITLE
Make sentinel name configurable

### DIFF
--- a/backend/entityservice/cache/connection.py
+++ b/backend/entityservice/cache/connection.py
@@ -7,7 +7,7 @@ from entityservice.settings import Config as config
 logger = structlog.get_logger()
 redis_host = config.REDIS_SERVER
 redis_pass = config.REDIS_PASSWORD
-redis_port = 26379
+redis_sentinel_port = 26379
 
 
 def connect_to_redis(read_only=False):
@@ -15,15 +15,16 @@ def connect_to_redis(read_only=False):
     Get a connection to the master redis service.
 
     """
-    logger.debug("Connecting to redis", server=redis_host, port=redis_port)
+    logger.debug("Connecting to redis", server=redis_host, port=redis_sentinel_port)
     if config.REDIS_USE_SENTINEL:
-        sentinel = Sentinel([(redis_host, redis_port)], password=redis_pass, socket_timeout=5)
+        sentinel_service = Sentinel([(redis_host, redis_sentinel_port)], password=redis_pass, socket_timeout=5)
+        sentinel_name = config.REDIS_SENTINEL_NAME
         if read_only:
             logger.debug("Looking up read only redis slave using sentinel protocol")
-            r = sentinel.slave_for('mymaster')
+            r = sentinel_service.slave_for(sentinel_name)
         else:
             logger.debug("Looking up redis master using sentinel protocol")
-            r = sentinel.master_for('mymaster')
+            r = sentinel_service.master_for(sentinel_name)
     else:
         r = redis.StrictRedis(host=redis_host, password=redis_pass)
     return r

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -23,6 +23,7 @@ class Config(object):
     REDIS_SERVER = os.getenv('REDIS_SERVER', 'redis')
     REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', '')
     REDIS_USE_SENTINEL = os.getenv('REDIS_USE_SENTINEL', 'false').lower() == "true"
+    REDIS_SENTINEL_NAME = os.getenv('REDIS_SENTINEL_NAME', 'mymaster')
 
     MINIO_SERVER = os.getenv('MINIO_SERVER', 'minio:9000')
     MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY', '')

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -15,12 +15,12 @@ data:
 
   {{ if .Values.provision.redis }}
   REDIS_SERVER: {{ .Release.Name }}-{{ index .Values "redis-ha" "nameOverride" }}
-  REDIS_USE_SENTINEL: "true"
   {{ else }}
   REDIS_SERVER: {{ required "redis.server is required if provision.redis is set to false or absent." .Values.redis.server }}
-  REDIS_USE_SENTINEL: {{ required "redis.use_sentinel is required if provision.redis is set to false or absent." .Values.redis.use_sentinel }}
   {{ end }}
   # REDIS_PASSWORD provided as a secret
+  REDIS_USE_SENTINEL: {{ required "redis.useSentinel is required." .Values.redis.useSentinel | quote }}
+  REDIS_SENTINEL_NAME: {{ required "redis.sentinelName is required." .Values.redis.sentinelName }}
 
   {{ if .Values.provision.minio }}
   MINIO_SERVER: "{{ .Release.Name }}-minio:9000"

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -244,14 +244,15 @@ global:
 ## In this section, we are not installing any redis pods. The main goal is to get configuration values for the
 ## other services.
 redis:
-  ## Note the `server` and `use_sentinel` options are ignored if provisioning redis
+  ## Note the `server` options are ignored if provisioning redis
   ## using this chart.
 
   ## External redis server url/ip
   server: ""
 
-  ## Does the external redis server support the sentinel protocol?
-  use_sentinel: false
+  ## Does the redis server support the sentinel protocol
+  useSentinel: true
+  sentinelName: "mymaster"
 
   ## Note if deploying redis-ha you MUST have the same password below!
   password: "exampleRedisPassword"


### PR DESCRIPTION
As Wilko pointed out in https://github.com/data61/anonlink-entity-service/pull/430#discussion_r327941353 all the other redis settings are fully configurable except for the sentinel name. This fixes this poor state of affairs.