### PR TITLE
Feature k8s pods log extraction

### DIFF
--- a/.azurePipeline/getPodsLogs.py
+++ b/.azurePipeline/getPodsLogs.py
@@ -44,8 +44,9 @@ def info_from_pod(_pod, _directory, _release_name):
                 'name': name_container, 'image': image_name, 'restart_count': restart_count}
         
         with open(_directory / 'pod-{}_container-{}.log'.format(info['short_pod_name'], info['name']), 'wt') as f:
-            json.dump(info, f, indent=2, sort_keys=True)
-            f.write('\n\n')
+            for key, value in info.items():
+                f.write("{}: {}\n".format(key, value))
+            f.write('{}\n\n'.format('-'*25))
         with open(_directory / 'pod-{}_container-{}.log'.format(info['short_pod_name'], info['name']), 'at') as f:
             get_logs_container(info, f)
         if restart_count > 0:

--- a/.azurePipeline/getPodsLogs.py
+++ b/.azurePipeline/getPodsLogs.py
@@ -32,14 +32,15 @@ def get_logs_container(container_info, file, previous=False):
     file.write(colors.strip_color(output.stdout.decode("utf-8")))
 
 
-def info_from_pod(_pod, _directory):
+def info_from_pod(_pod, _directory, _release_name):
     pod_name = _pod.get('metadata').get('name')
     list_containers = _pod.get('status').get('containerStatuses')
     for container in list_containers:
         name_container = container.get('name')
         restart_count = container.get('restartCount')
         image_name = container.get('image')
-        info = {'full_pod_name': pod_name, 'short_pod_name': pod_name[len('benchmark-es-data61-xyz-'):],
+        prefix_to_remove = "{}-".format(_release_name)
+        info = {'full_pod_name': pod_name, 'short_pod_name': pod_name[len(prefix_to_remove):],
                 'name': name_container, 'image': image_name, 'restart_count': restart_count}
         
         with open(_directory / 'pod-{}_container-{}.log'.format(info['short_pod_name'], info['name']), 'wt') as f:
@@ -66,7 +67,7 @@ def main():
     release_name = sys.argv[2]
     list_pods = get_list_pods(release_name)
     for pod in list_pods:
-        info_from_pod(pod, directory)
+        info_from_pod(pod, directory, release_name)
 
 
 if __name__ == '__main__':

--- a/.azurePipeline/getPodsLogs.py
+++ b/.azurePipeline/getPodsLogs.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""
+The script will currently be used in the Azure Pipeline to get back the logs of the pods when a test is failing
+allowing developers to document the issue.
+"""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+# The namespace is not configurable as we are expected to run this script only in Azure Dev-Ops which deployed the
+# service only in this namespace.
+NAMESPACE = "test-azure"
+
+
+def get_list_pods(_release_name):
+    cmd = "kubectl --namespace {} get pods -l release={} -o json".format(NAMESPACE, _release_name)
+    r = subprocess.run(cmd.split(" "), capture_output=True)
+    items_from_release = json.loads(r.stdout)['items']
+    return items_from_release
+
+
+def get_logs_container(container_info, file, previous=False):
+    cmd = "kubectl --namespace {} logs {} {}".format(NAMESPACE, container_info['full_pod_name'], container_info['name'])
+    if previous:
+        cmd += " --previous"
+    subprocess.call(cmd.split(" "), stdout=file)
+
+
+def info_from_pod(_pod, _directory):
+    pod_name = _pod.get('metadata').get('name')
+    list_containers = _pod.get('status').get('containerStatuses')
+    for container in list_containers:
+        name_container = container.get('name')
+        restart_count = container.get('restartCount')
+        image_name = container.get('image')
+        info = {'full_pod_name': pod_name, 'short_pod_name': pod_name[len('benchmark-es-data61-xyz-'):],
+                'name': name_container, 'image': image_name, 'restart_count': restart_count}
+        
+        with open(_directory / 'pod-{}_container-{}.log'.format(info['short_pod_name'], info['name']), 'wt') as f:
+            json.dump(info, f, indent=2, sort_keys=True)
+            f.write('\n\n')
+        with open(_directory / 'pod-{}_container-{}.log'.format(info['short_pod_name'], info['name']), 'at') as f:
+            get_logs_container(info, f)
+        if restart_count > 0:
+            with open(_directory / 'pod-{}_container-{}-previous.log'.format(info['short_pod_name'], info['name']), 'at') as f:
+                get_logs_container(info, f, previous=True)
+
+
+def main():
+    """
+    Main method of this script. It requires two arguments: a path where to store the logs from the pods, and the release
+    name. The release name is used to get the list of pods from the selected release.
+    """
+    if len(sys.argv) < 3:
+        raise ValueError("Missing arguments to select the folder where to store the logs and the release name.")
+    if len(sys.argv) > 3:
+        raise ValueError("Too many arguments provided to the method. Only folder where to store the"
+                         " logs and the release name are required.")
+    directory = Path(sys.argv[1])
+    release_name = sys.argv[2]
+    list_pods = get_list_pods(release_name)
+    for pod in list_pods:
+        info_from_pod(pod, directory)
+
+
+if __name__ == '__main__':
+    main()

--- a/.azurePipeline/getPodsLogs.py
+++ b/.azurePipeline/getPodsLogs.py
@@ -5,6 +5,7 @@ The script will currently be used in the Azure Pipeline to get back the logs of 
 allowing developers to document the issue.
 """
 
+import colors
 import json
 from pathlib import Path
 import subprocess
@@ -26,7 +27,9 @@ def get_logs_container(container_info, file, previous=False):
     cmd = "kubectl --namespace {} logs {} {}".format(NAMESPACE, container_info['full_pod_name'], container_info['name'])
     if previous:
         cmd += " --previous"
-    subprocess.call(cmd.split(" "), stdout=file)
+    output = subprocess.run(cmd.split(" "), capture_output=True)
+    # The returned logs contain colored characters. So use ansicolors to strip them out before writing them to file.
+    file.write(colors.strip_color(output.stdout.decode("utf-8")))
 
 
 def info_from_pod(_pod, _directory):

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -14,10 +14,12 @@ steps:
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.6'
+  condition: failed()
 - script: |
     echo "Copy the pods' logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
     python ./azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
   displayName: 'Copy the logs from the service pods.'
+  condition: failed()
   env:
     KUBECONFIG: ${{ parameters.kubeConfigFile }}
 - task: PublishPipelineArtifact@1
@@ -25,3 +27,4 @@ steps:
   inputs:
     artifactName: Artifacts
     targetPath: ${{ parameters.logsFolderPath }}
+  condition: failed()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -4,6 +4,9 @@
 # `logsFolderPath` is the folder where the logs from the pods will be stored.
 # `releaseName` is the name of the release used to get the relevant list of pods.
 # `kubeConfigFile` is the kubeConfigFile path.
+# `JobAttempt` should be provided by the variable `System.JobAttempt` which is not directly accessible from the template.
+#   This incremental value is required to be able to re-run the job, in fact the `PublishPipelineArtifact` step fails
+#   if the build publish an artifact with the same name twice.
 
 parameters:
   logsFolderPath: ''

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -16,7 +16,11 @@ steps:
     versionSpec: '3.7'
   condition: failed()
 - script: |
-    echo "Copy the pods' logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
+    pip install ansicolors
+  displayName: 'Install Python dependencies.'
+  condition: failed()
+- script: |
+    echo "Copy the pods logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
     python .azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
   displayName: 'Copy the logs from the service pods.'
   condition: failed()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -32,6 +32,6 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:
-    artifactName: PodLogs
+    artifactName: PodLogs${{ System.JobAttempt }}
     targetPath: ${{ parameters.logsFolderPath }}
   condition: always()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -17,7 +17,7 @@ steps:
   condition: failed()
 - script: |
     echo "Copy the pods' logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
-    python ./azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
+    python .azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
   displayName: 'Copy the logs from the service pods.'
   condition: failed()
   env:

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.6'
+    versionSpec: '3.7'
   condition: failed()
 - script: |
     echo "Copy the pods' logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -14,24 +14,24 @@ steps:
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '3.7'
-  condition: failed()
+  condition: always()
 
 - script: |
     pip install ansicolors
   displayName: 'Install Python dependencies.'
-  condition: failed()
+  condition: always()
 
 - script: |
     echo "Copy the pods logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
     python .azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
   displayName: 'Copy the logs from the service pods.'
-  condition: failed()
+  condition: always()
   env:
     KUBECONFIG: ${{ parameters.kubeConfigFile }}
-    
+
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:
     artifactName: PodLogs
     targetPath: ${{ parameters.logsFolderPath }}
-  condition: failed()
+  condition: always()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -25,6 +25,6 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:
-    artifactName: Artifacts
+    artifactName: PodLogs
     targetPath: ${{ parameters.logsFolderPath }}
   condition: failed()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -32,6 +32,6 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:
-    artifactName: PodLogs${{ System.JobAttempt }}
+    artifactName: PodLogs${{ variables.System.JobAttempt }}
     targetPath: ${{ parameters.logsFolderPath }}
   condition: always()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -9,6 +9,7 @@ parameters:
   logsFolderPath: ''
   releaseName: ''
   kubeConfigFile: ''
+  JobAttempt: ''
 
 steps:
 - task: UsePythonVersion@0
@@ -32,6 +33,6 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:
-    artifactName: PodLogs${{ variables.System.JobAttempt }}
+    artifactName: PodLogs${{ parameters.JobAttempt }}
     targetPath: ${{ parameters.logsFolderPath }}
   condition: always()

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -15,10 +15,12 @@ steps:
   inputs:
     versionSpec: '3.7'
   condition: failed()
+
 - script: |
     pip install ansicolors
   displayName: 'Install Python dependencies.'
   condition: failed()
+
 - script: |
     echo "Copy the pods logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
     python .azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
@@ -26,6 +28,7 @@ steps:
   condition: failed()
   env:
     KUBECONFIG: ${{ parameters.kubeConfigFile }}
+    
 - task: PublishPipelineArtifact@1
   displayName: 'Publish pods logs in Azure'
   inputs:

--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -1,0 +1,27 @@
+# Template to login into Dockerhub, build a docker image and push it.
+
+# Parameters:
+# `logsFolderPath` is the folder where the logs from the pods will be stored.
+# `releaseName` is the name of the release used to get the relevant list of pods.
+# `kubeConfigFile` is the kubeConfigFile path.
+
+parameters:
+  logsFolderPath: ''
+  releaseName: ''
+  kubeConfigFile: ''
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.6'
+- script: |
+    echo "Copy the pods' logs from the release '${{ parameters.releaseName }}' to '${{ parameters.logsFolderPath }}'."
+    python ./azurePipeline/getPodsLogs.py ${{ parameters.logsFolderPath }} ${{ parameters.releaseName }}
+  displayName: 'Copy the logs from the service pods.'
+  env:
+    KUBECONFIG: ${{ parameters.kubeConfigFile }}
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish pods logs in Azure'
+  inputs:
+    artifactName: Artifacts
+    targetPath: ${{ parameters.logsFolderPath }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,7 +266,14 @@ stages:
         testResultsFormat: 'JUnit'
         testResultsFiles: 'k8s-results.xml'
         testRunTitle: 'Publish kubernetes test results'
-        failTaskOnFailedTests: true 
+        failTaskOnFailedTests: true
+    # Publish all the pods logs if some tests failed.
+    - template: .azurePipeline/templatePublishLogsFromPods.yml
+      parameters:
+        logsFolderPath: $(Build.ArtifactStagingDirectory)
+        releaseName: $(DEPLOYMENT)
+        kubeConfigFile: $(KUBECONFIGFILE)
+      condition: failed()
     # And do a lot of cleaning.
     # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,7 +273,6 @@ stages:
         logsFolderPath: $(Build.ArtifactStagingDirectory)
         releaseName: $(DEPLOYMENT)
         kubeConfigFile: $(KUBECONFIGFILE)
-      condition: failed()
     # And do a lot of cleaning.
     # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,6 +273,7 @@ stages:
         logsFolderPath: $(Build.ArtifactStagingDirectory)
         releaseName: $(DEPLOYMENT)
         kubeConfigFile: $(KUBECONFIGFILE)
+        JobAttempt: $(System.JobAttempt)
     # And do a lot of cleaning.
     # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
     - script: |

--- a/backend/entityservice/tests/test_admin.py
+++ b/backend/entityservice/tests/test_admin.py
@@ -24,3 +24,7 @@ def test_status(record_property):
     assert 'rate' in status_json
     assert 'project_count' in status_json
 
+
+def test_fail():
+    # TO BE DELETED
+    raise Exception("Yep, this is expected")

--- a/backend/entityservice/tests/test_admin.py
+++ b/backend/entityservice/tests/test_admin.py
@@ -24,7 +24,3 @@ def test_status(record_property):
     assert 'rate' in status_json
     assert 'project_count' in status_json
 
-
-def test_fail():
-    # TO BE DELETED
-    raise Exception("Yep, this is expected")

--- a/docs/devops.rst
+++ b/docs/devops.rst
@@ -25,7 +25,7 @@ The continuous integration stages are:
 - runs the benchmark using ``docker-compose`` and publishes the results as an artifact in Azure
 - runs the tutorial tests using ``docker-compose`` and publishes the results in Azure
 - runs the integration tests by deploying the whole service on ``Kubernetes``, running the integration
-  tests and publishing the results in Azure.
+  tests and publishing the results in Azure. It also publishes the pods logs if some tests failed.
 
 The build pipeline is triggered for every push on every branch. It is not triggered by Pull
 Requests to avoid duplicate testing and building potentially untrusted external code.


### PR DESCRIPTION
Add an extra step in our azure pipeline to publish the logs of the entity-service pods when tests are failing.
First, use a python script to download the logs (easier with python than bash, and I already had the script locally), then, create an azure template for steps running the python script and publishing the logs in azure artifacts, finally integrate this template in the main pipeline.

Note: I included a commit which will need to be reversed: I introduce a test made to fail (directly raising an exception).