### PR TITLE
Feature k8s logging

### DIFF
--- a/deployment/entity-service/Chart.yaml
+++ b/deployment/entity-service/Chart.yaml
@@ -1,6 +1,6 @@
 name: entity-service
 appVersion: 1.11.2
-version: 1.12.0
+version: 1.13.0
 description: Privacy preserving record linkage service
 sources:
   - https://github.com/data61/anonlink-entity-service

--- a/deployment/entity-service/templates/api-deployment.yaml
+++ b/deployment/entity-service/templates/api-deployment.yaml
@@ -94,18 +94,18 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 5
-          {{- if .Values.workers.loggingCfgm }}
+          {{- if .Values.workers.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
           {{- end }}
-      {{- if .Values.workers.loggingCfgm }}
+      {{- if .Values.workers.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:
-            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            name: {{ template "es.fullname" . }}-logging
             items:
-              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+              - key: "loggingCfg"
                 path: "logging_file.yaml"
       {{- end }}
       {{- if .Values.api.pullSecret }}

--- a/deployment/entity-service/templates/api-deployment.yaml
+++ b/deployment/entity-service/templates/api-deployment.yaml
@@ -94,6 +94,20 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 5
+          {{- if .Values.workers.loggingCfgm }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /var/config
+          {{- end }}
+      {{- if .Values.workers.loggingCfgm }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            items:
+              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+                path: "logging_file.yaml"
+      {{- end }}
       {{- if .Values.api.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.api.pullSecret }}

--- a/deployment/entity-service/templates/api-deployment.yaml
+++ b/deployment/entity-service/templates/api-deployment.yaml
@@ -94,12 +94,12 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 5
-          {{- if .Values.workers.loggingCfg }}
+          {{- if .Values.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
           {{- end }}
-      {{- if .Values.workers.loggingCfg }}
+      {{- if .Values.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -66,7 +66,7 @@ data:
   MIN_ENCODING_SIZE: "8"
   MAX_ENCODING_SIZE: "1024"
 
-  {{- if .Values.workers.loggingCfgm }}
+  {{- if .Values.workers.loggingCfg }}
   # Not from the setting.py file.
   LOG_CFG: "/var/config/logging_file.yaml"
   {{- end }}

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -66,7 +66,7 @@ data:
   MIN_ENCODING_SIZE: "8"
   MAX_ENCODING_SIZE: "1024"
 
+  {{- if .Values.workers.loggingCfgm }}
   # Not from the setting.py file.
-  {{ if .Values.workers.LOG_CFG }}
-  LOG_CFG: {{ .Values.workers.LOG_CFG | quote }}
-  {{ end }}
+  LOG_CFG: "/var/config/logging_file.yaml"
+  {{- end }}

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -66,7 +66,7 @@ data:
   MIN_ENCODING_SIZE: "8"
   MAX_ENCODING_SIZE: "1024"
 
-  {{- if .Values.workers.loggingCfg }}
+  {{- if .Values.loggingCfg }}
   # Not from the setting.py file.
   LOG_CFG: "/var/config/logging_file.yaml"
   {{- end }}

--- a/deployment/entity-service/templates/highmemory-worker-deployment.yaml
+++ b/deployment/entity-service/templates/highmemory-worker-deployment.yaml
@@ -59,7 +59,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "es.fullname" . }}
                   key: minioSecretKey
-
           command:
             - "celery"
             - "-A"
@@ -70,10 +69,24 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute,highmemory"
+          {{- if .Values.workers.loggingCfgm }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /var/config
+          {{- end }}
           args:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+      {{- if .Values.workers.loggingCfgm }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            items:
+              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+                path: "logging_file.yaml"
+      {{- end }}
       {{- if .Values.api.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.api.pullSecret }}

--- a/deployment/entity-service/templates/highmemory-worker-deployment.yaml
+++ b/deployment/entity-service/templates/highmemory-worker-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute,highmemory"
-          {{- if .Values.workers.loggingCfg }}
+          {{- if .Values.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
@@ -78,7 +78,7 @@ spec:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-      {{- if .Values.workers.loggingCfg }}
+      {{- if .Values.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:

--- a/deployment/entity-service/templates/highmemory-worker-deployment.yaml
+++ b/deployment/entity-service/templates/highmemory-worker-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute,highmemory"
-          {{- if .Values.workers.loggingCfgm }}
+          {{- if .Values.workers.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
@@ -78,13 +78,13 @@ spec:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-      {{- if .Values.workers.loggingCfgm }}
+      {{- if .Values.workers.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:
-            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            name: {{ template "es.fullname" . }}-logging
             items:
-              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+              - key: loggingCfg
                 path: "logging_file.yaml"
       {{- end }}
       {{- if .Values.api.pullSecret }}

--- a/deployment/entity-service/templates/logging-configmap.yaml
+++ b/deployment/entity-service/templates/logging-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.workers.loggingCfg }}
+{{- if .Values.loggingCfg }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,5 @@ metadata:
     {{- include "es.release_labels" . | indent 4 }}
 data:
   loggingCfg: |-
-{{ .Values.workers.loggingCfg | indent 4 }}
+{{ .Values.loggingCfg | indent 4 }}
 {{- end }}

--- a/deployment/entity-service/templates/logging-configmap.yaml
+++ b/deployment/entity-service/templates/logging-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.workers.loggingCfg }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "es.fullname" . }}-logging
+  labels:
+    {{- include "es.release_labels" . | indent 4 }}
+data:
+  loggingCfg: |-
+{{ .Values.workers.loggingCfg | indent 4 }}
+{{- end }}

--- a/deployment/entity-service/templates/worker-deployment.yaml
+++ b/deployment/entity-service/templates/worker-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute"
-          {{- if .Values.workers.loggingCfg }}
+          {{- if .Values.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
@@ -78,7 +78,7 @@ spec:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-      {{- if .Values.workers.loggingCfg }}
+      {{- if .Values.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:

--- a/deployment/entity-service/templates/worker-deployment.yaml
+++ b/deployment/entity-service/templates/worker-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute"
-          {{- if .Values.workers.loggingCfgm }}
+          {{- if .Values.workers.loggingCfg }}
           volumeMounts:
             - name: config-volume
               mountPath: /var/config
@@ -78,13 +78,13 @@ spec:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-      {{- if .Values.workers.loggingCfgm }}
+      {{- if .Values.workers.loggingCfg }}
       volumes:
         - name: config-volume
           configMap:
-            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            name: {{ template "es.fullname" . }}-logging
             items:
-              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+              - key: loggingCfg
                 path: "logging_file.yaml"
       {{- end }}
       {{- if .Values.api.pullSecret }}

--- a/deployment/entity-service/templates/worker-deployment.yaml
+++ b/deployment/entity-service/templates/worker-deployment.yaml
@@ -59,7 +59,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "es.fullname" . }}
                   key: minioSecretKey
-
           command:
             - "celery"
             - "-A"
@@ -70,10 +69,24 @@ spec:
             - "fair"
             - "-Q"
             - "celery,compute"
+          {{- if .Values.workers.loggingCfgm }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /var/config
+          {{- end }}
           args:
           {{- range $key, $value := .Values.workers.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+      {{- if .Values.workers.loggingCfgm }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ required ".workers.logging_cfgm.name is required to provide the name of the configmap where the logging configuration is stored." .Values.workers.loggingCfgm.name }}
+            items:
+              - key: {{ required ".workers.logging_cfgm.key is required to provide the key in the configmap which value is the content of the logging configuration." .Values.workers.loggingCfgm.key }}
+                path: "logging_file.yaml"
+      {{- end }}
       {{- if .Values.api.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.api.pullSecret }}

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -172,10 +172,15 @@ workers:
   ## Default is 30 days:
   CACHE_EXPIRY_SECONDS: "2592000"
 
-  ## Optional path to a logging configuration file
-  ## Eventually this config can be stored in a configmap
-  ## See https://github.com/data61/anonlink-entity-service/issues/323
-  #LOG_CFG: "entityservice/verbose_logging.yaml"
+  ## Optional parameters to configure the logging used by the workers and the flask app. By default, the application
+  ## will use the logging configuration specified in the `default_logging.yaml` file at the time the docker image has
+  ## been created.
+  ## Cf `production-deployment.rst` documentation on how to create a configmap from a logging file.
+  ## loggingCfgm.name is the name of the configmap from which to read from to access the logging configuration file.
+  ## loggingCfgm.key is the key which associated value in the configmap is the content of the logging configuration file.
+  #loggingCfgm:
+  #  name: configmapname
+  #  key: keyInTheConfigMap
 
   ## Specific configuration for celery
   ## Note that these configurations are the same for a "normal" worker, and a "highmemeroy" one,

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -173,7 +173,30 @@ workers:
   CACHE_EXPIRY_SECONDS: "2592000"
 
   ## Custom logging file used to override the default settings. Will be used by the workers and the flask container.
+  ## Example of logging configuration:
   #loggingCfg: |-
+  #  version: 1
+  #  disable_existing_loggers: False
+  #  formatters:
+  #    simple:
+  #      format: "%(message)s"
+  #    file:
+  #      format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
+  #  filters:
+  #    stderr_filter:
+  #      (): entityservice.logger_setup.StdErrFilter
+  #    stdout_filter:
+  #      (): entityservice.logger_setup.StdOutFilter
+  #  handlers:
+  #    stdout:
+  #      class: logging.StreamHandler
+  #      level: DEBUG
+  #      formatter: simple
+  #      filters: [stdout_filter]
+  #      stream: ext://sys.stdout
+  #  root:
+  #    level: INFO
+  #    handlers: [stdout]
 
   ## Specific configuration for celery
   ## Note that these configurations are the same for a "normal" worker, and a "highmemeroy" one,

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -172,15 +172,8 @@ workers:
   ## Default is 30 days:
   CACHE_EXPIRY_SECONDS: "2592000"
 
-  ## Optional parameters to configure the logging used by the workers and the flask app. By default, the application
-  ## will use the logging configuration specified in the `default_logging.yaml` file at the time the docker image has
-  ## been created.
-  ## Cf `production-deployment.rst` documentation on how to create a configmap from a logging file.
-  ## loggingCfgm.name is the name of the configmap from which to read from to access the logging configuration file.
-  ## loggingCfgm.key is the key which associated value in the configmap is the content of the logging configuration file.
-  #loggingCfgm:
-  #  name: configmapname
-  #  key: keyInTheConfigMap
+  ## Custom logging file used to override the default settings. Will be used by the workers and the flask container.
+  #loggingCfg: |-
 
   ## Specific configuration for celery
   ## Note that these configurations are the same for a "normal" worker, and a "highmemeroy" one,

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -172,32 +172,6 @@ workers:
   ## Default is 30 days:
   CACHE_EXPIRY_SECONDS: "2592000"
 
-  ## Custom logging file used to override the default settings. Will be used by the workers and the flask container.
-  ## Example of logging configuration:
-  #loggingCfg: |-
-  #  version: 1
-  #  disable_existing_loggers: False
-  #  formatters:
-  #    simple:
-  #      format: "%(message)s"
-  #    file:
-  #      format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
-  #  filters:
-  #    stderr_filter:
-  #      (): entityservice.logger_setup.StdErrFilter
-  #    stdout_filter:
-  #      (): entityservice.logger_setup.StdOutFilter
-  #  handlers:
-  #    stdout:
-  #      class: logging.StreamHandler
-  #      level: DEBUG
-  #      formatter: simple
-  #      filters: [stdout_filter]
-  #      stream: ext://sys.stdout
-  #  root:
-  #    level: INFO
-  #    handlers: [stdout]
-
   ## Specific configuration for celery
   ## Note that these configurations are the same for a "normal" worker, and a "highmemeroy" one,
   ## except for the requested resources and replicaCount which can differ.
@@ -350,3 +324,29 @@ provision:
   minio: true
   postgresql: true
   redis: true
+
+## Custom logging file used to override the default settings. Will be used by the workers and the flask container.
+## Example of logging configuration:
+#loggingCfg: |-
+#  version: 1
+#  disable_existing_loggers: False
+#  formatters:
+#    simple:
+#      format: "%(message)s"
+#    file:
+#      format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
+#  filters:
+#    stderr_filter:
+#      (): entityservice.logger_setup.StdErrFilter
+#    stdout_filter:
+#      (): entityservice.logger_setup.StdOutFilter
+#  handlers:
+#    stdout:
+#      class: logging.StreamHandler
+#      level: DEBUG
+#      formatter: simple
+#      filters: [stdout_filter]
+#      stream: ext://sys.stdout
+#  root:
+#    level: INFO
+#    handlers: [stdout]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,10 +7,7 @@ Changelog
 Next Version
 ------------
 
-Logging configurable in the deployed entity service by creating a configmap
-containing the configuration file, and pointing to it via the dictionary ``workers.loggingCfgm``
-having ``name`` and ``key`` as keys, where ``name`` is the name of the configmap to use, and ``key``
-the key to the value containing the logging configuration.
+Logging configurable in the deployed entity service by using the key ``loggingCfg``.
 
 
 Several old settings have been removed from the default values.yaml and docker files:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 Next Version
 ------------
 
+Logging configurable in the deployed entity service by creating a configmap
+containing the configuration file, and pointing to it via the dictionary ``workers.loggingCfgm``
+having ``name`` and ``key`` as keys, where ``name`` is the name of the configmap to use, and ``key``
+the key to the value containing the logging configuration.
+
+
 Several old settings have been removed from the default values.yaml and docker files:
 - ``SMALL_COMPARISON_CHUNK_SIZE``
 - ``LARGE_COMPARISON_CHUNK_SIZE``

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -248,6 +248,26 @@ To use a separate install of redis using the server ``shared-redis-ha-redis-ha.d
          --set redis.use_sentinel=true
 
 
+Logging Configuration
+---------------------
+
+To provide a specific logging configurations used by the workers and the flask container, few steps are required.
+
+First, create a `yaml` logging file which will be used by the application. See `backend/entityservice/default_logging.yaml`
+ or `backend/entityservice/verbose_logging.yaml` as examples.
+
+Then, create a configmap from the logging file::
+
+    kubectl create configmap logconfigmap \
+         --from-file=loggingValues=verbose_logging.yaml
+
+where ``logconfigmap`` is the created name of the configmap, ``loggingValues`` is the key under which the file
+``verbose_logging.yaml`` will be stored.
+
+Finally, in the deployment configuration file, set the parameters ``workers.loggingCfgm.name`` to the selected configmap
+name and ``workers.loggingCfgm.key`` to the selected key, which in our example are respectively ``logconfigmap``
+and ``loggingValues``.
+
 Uninstalling
 ------------
 

--- a/docs/production-deployment.rst
+++ b/docs/production-deployment.rst
@@ -248,26 +248,6 @@ To use a separate install of redis using the server ``shared-redis-ha-redis-ha.d
          --set redis.use_sentinel=true
 
 
-Logging Configuration
----------------------
-
-To provide a specific logging configurations used by the workers and the flask container, few steps are required.
-
-First, create a `yaml` logging file which will be used by the application. See `backend/entityservice/default_logging.yaml`
- or `backend/entityservice/verbose_logging.yaml` as examples.
-
-Then, create a configmap from the logging file::
-
-    kubectl create configmap logconfigmap \
-         --from-file=loggingValues=verbose_logging.yaml
-
-where ``logconfigmap`` is the created name of the configmap, ``loggingValues`` is the key under which the file
-``verbose_logging.yaml`` will be stored.
-
-Finally, in the deployment configuration file, set the parameters ``workers.loggingCfgm.name`` to the selected configmap
-name and ``workers.loggingCfgm.key`` to the selected key, which in our example are respectively ``logconfigmap``
-and ``loggingValues``.
-
 Uninstalling
 ------------
 


### PR DESCRIPTION
This PR is about adding possibility to configure the entity-service logging in deployment.
To do this, a user has to:
 - create a logging configuration file which the entity-service can use (out of scope for this PR)
 - create and publish on k8s a configmap from this logging configuration file (documented)
 - add the corresponding parameters in the deployment configuration (documented in docs and in `values.yaml`)

Under the hood and following the documentation, a configmap is created from the logging file with a selected key. Without a key, each key from the configmap would create its own file when loaded in a volume.
Then, when selecting a logging configmap at deployment time, the env var configmap will update the env var `LOG_CFG` pointing to a file which will be created from the logging configmap and mounted to each container which uses the env var `LOG_CFG`, i.e. the workers, the `init_db`, and the entity flask.

Some notes:
 - I would have loved another solution where you can simply provide a path to a file when starting a deployment, but this is not yet by kubernetes (it cannot load a file which the templates are not aware of, which is not convenient for users)
 - providing the whole log file directly in the deployment configuration is a bad idea because some characters are interpreted by kubernetes (mainly the %, but maybe others)
 - providing a default configuration in the `vlaues.yaml` file is a bad idea because a user would have to overwrite each single value, making it a horrible experience to remove a section of the default configuration (as we need to overwrite each value, nothing is really deleted from the defaults)
 - this logging config map could be extended to include more generic configurations read from files if required.