### PR TITLE
Feature delete mapping

### DIFF
--- a/backend/entityservice/api_def/swagger.yaml
+++ b/backend/entityservice/api_def/swagger.yaml
@@ -40,7 +40,7 @@ info:
     The personally identifiable information used for linking is first locally transformed
     to anonymous linking codes called [Cryptographic Longterm Keys](concepts.html#cryptographic-longterm-key)
     (CLKs). Each party then uploads its CLKs to the service for matching.
-    The service supports four different [types of outputs](concepts.html#result-types)
+    The service supports three different [types of outputs](concepts.html#result-types)
     of matching results, varying in privacy properties.
     For the CLKs to be comparable, the parties need to agree on and follow a particular
     [linkage schema](concepts.html#schema) and agree on a shared secret before generating
@@ -68,7 +68,7 @@ info:
 
     ## Matching Protocols
 
-    The Entity Service supports four different **result types** with varying privacy properties which define the produced result,
+    The Entity Service supports three different **result types** with varying privacy properties which define the produced result,
     and who may see the which part of the output.
 
     See the documentation section on [output types](./concepts.html#result-types).

--- a/backend/entityservice/api_def/swagger.yaml
+++ b/backend/entityservice/api_def/swagger.yaml
@@ -75,13 +75,12 @@ info:
 
     The options are:
 
-      * `"mapping"` - Creates a lookup table of the form `indexA = indexB`.
       * `"permutations"` - Creates random permutations and a mask.
       * `"similarity_scores"` - Outputs a list of similarity scores of `[indexA, indexB, score]`, where `score`
         represents the likelihood that `indexA = indexB`.
       * `"groups"` - Outputs a list of groups of records, where each group represents one entity.
 
-    Only `"groups"` supports multi-party linkage. `"mapping"`, `"permutations"`, and `"similarity_scores"` only support linkage
+    Only `"groups"` supports multi-party linkage. `"permutations"` and `"similarity_scores"` only support linkage
     with two parties.
 
 
@@ -193,8 +192,8 @@ paths:
         The parts of the computed linkage results that are accessable by the different tokens depends on the
         `result_type`:
 
-        - `"mapping"`, `"similarity_scores"`, or `"groups"`\
-        If the `result_type` is `"mapping"`, `"similarity_scores"`, or `"groups"` then the results can be accessed with the
+        - `"similarity_scores"`, or `"groups"`\
+        If the `result_type` is `"similarity_scores"` or `"groups"` then the results can be accessed with the
         `result_token``token`, which is provided when initially creating the mapping.
 
         - `"permutations"`\
@@ -202,7 +201,7 @@ paths:
         their individual `receipt_token`, which they obtain when adding data to the mapping.
         The mask can be accessed with the `result_token`.
 
-        Only `"groups"` supports multi-party linkage. If the result type is `"mapping"`,  `"similarity_scores"`, or
+        Only `"groups"` supports multi-party linkage. If the result type is `"similarity_scores"` or
         `"permutations"`, then the number of parties must be 2.
 
       parameters:
@@ -508,19 +507,6 @@ paths:
         Note if the result isn't ready, a `404` will be returned.
 
 
-        ### result_type = "mapping"
-
-        The mapping of indices between parties. Data is returned as `json` object e.g,
-
-            {
-                "mapping":
-                    {
-                        "0": "5",
-                        "2": "0"
-                    }
-            }
-
-
         ### result_type = "similarity_scores"
 
         The list of the indices of potential matches and their similarity score
@@ -718,10 +704,9 @@ definitions:
     description: |
       Defines the output type of the mapping. Multi-party linkage requires `"groups"` to be used.
     enum:
-      - similarity_scores
-      - mapping
-      - permutations
       - groups
+      - permutations
+      - similarity_scores
 
   RunState:
     type: string

--- a/backend/entityservice/init-db-schema.sql
+++ b/backend/entityservice/init-db-schema.sql
@@ -7,10 +7,10 @@ CASCADE;
 DROP TYPE IF EXISTS MAPPINGRESULT;
 
 CREATE TYPE MAPPINGRESULT AS ENUM (
-  'mapping',
+  'groups',
   'permutations',
-  'similarity_scores',
-  'groups'
+  'similarity_scores'
+
 );
 
 -- The table of entity matching jobs

--- a/backend/entityservice/messages.py
+++ b/backend/entityservice/messages.py
@@ -1,3 +1,3 @@
 INVALID_ACCESS_MSG = "Invalid access token or project doesn't exist"
 
-INVALID_RESULT_TYPE_MESSAGE = 'result_type must be either "permutations", "mapping", "similarity_scores", or "groups"'
+INVALID_RESULT_TYPE_MESSAGE = 'result_type must be either "groups", "permutations", or "similarity_scores"'

--- a/backend/entityservice/models/project.py
+++ b/backend/entityservice/models/project.py
@@ -41,8 +41,9 @@ class Project(object):
         self.data = {}
         self.result = {}
 
-    VALID_RESULT_TYPES = {'permutations', 'mapping',
-                          'similarity_scores', 'groups'}
+    VALID_RESULT_TYPES = {'groups',
+                          'permutations',
+                          'similarity_scores'}
 
     @staticmethod
     def from_json(data):

--- a/backend/entityservice/tasks/permutation.py
+++ b/backend/entityservice/tasks/permutation.py
@@ -94,13 +94,13 @@ def permute_mapping_data(project_id, run_id, len_filters1, len_filters2, parent_
         random.shuffle(remaining_new_indexes)
         log.info("Assigning random indexes for {} matched entities".format(number_in_common))
 
-        for mapping_number, group in enumerate(groups):
+        for group_number, group in enumerate(groups):
             # It should not fail because the permutation result is only available for 2 parties, but let's be to safe.
             assert 2 == len(group)
             (_, a_index), (_, b_index) = sorted(group)
 
             # Choose the index in the new mapping (randomly)
-            mapping_index = remaining_new_indexes[mapping_number]
+            mapping_index = remaining_new_indexes[group_number]
 
             a_permutation[a_index] = mapping_index
             b_permutation[b_index] = mapping_index

--- a/backend/entityservice/tasks/permutation.py
+++ b/backend/entityservice/tasks/permutation.py
@@ -1,9 +1,6 @@
 import random
 
-import anonlink
-
 from entityservice.cache import encodings as encoding_cache
-
 from entityservice.async_worker import celery, logger
 from entityservice.database import DBConn, get_project_column, insert_mapping_result, get_dataprovider_ids, \
     get_run_result, insert_permutation, insert_permutation_mask
@@ -11,11 +8,6 @@ from entityservice.tasks.base_task import TracedTask
 from entityservice.tasks import mark_run_complete
 from entityservice.tasks.stats import calculate_comparison_rate
 from entityservice.utils import convert_mapping_to_list
-
-
-def groups_to_mapping(groups):
-    return {str(i): str(j)
-            for i, j in anonlink.solving.pairs_from_groups(groups)}
 
 
 @celery.task(base=TracedTask, ignore_result=True, args_as_tags=('project_id', 'run_id'))
@@ -30,17 +22,9 @@ def save_and_permute(similarity_result, project_id, run_id, parent_span):
     with DBConn() as db:
         result_type = get_project_column(db, project_id, 'result_type')
 
-        if result_type == "groups":
-            # Save the raw groups
-            log.debug("Saving the groups in the DB")
-            result_id = insert_mapping_result(db, run_id, groups)
-        else:
-            # Turn groups into mapping and save that
-            log.debug("Turning groups into mapping")
-            mapping = groups_to_mapping(groups)
-            log.debug("Saving mapping in the DB")
-            result_id = insert_mapping_result(db, run_id, mapping)
-
+        # Save the raw groups
+        log.debug("Saving the groups in the DB")
+        result_id = insert_mapping_result(db, run_id, groups)
         dp_ids = get_dataprovider_ids(db, project_id)
 
     log.info("Result saved to db with result id {}".format(result_id))
@@ -84,10 +68,7 @@ def permute_mapping_data(project_id, run_id, len_filters1, len_filters2, parent_
 
     with DBConn() as conn:
 
-        mapping_str = get_run_result(conn, run_id)
-
-        # Convert to int: int
-        mapping = {int(k): int(mapping_str[k]) for k in mapping_str}
+        groups = get_run_result(conn, run_id)
 
         log.info("Creating random permutations")
         log.debug("Entities in dataset A: {}, Entities in dataset B: {}".format(len_filters1, len_filters2))
@@ -100,7 +81,7 @@ def permute_mapping_data(project_id, run_id, len_filters1, len_filters2, parent_
         """
         smaller_dataset_size = min(len_filters1, len_filters2)
         log.debug("Smaller dataset size is {}".format(smaller_dataset_size))
-        number_in_common = len(mapping)
+        number_in_common = len(groups)
         a_permutation = {}  # Should be length of filters1
         b_permutation = {}  # length of filters2
 
@@ -113,8 +94,10 @@ def permute_mapping_data(project_id, run_id, len_filters1, len_filters2, parent_
         random.shuffle(remaining_new_indexes)
         log.info("Assigning random indexes for {} matched entities".format(number_in_common))
 
-        for mapping_number, a_index in enumerate(mapping):
-            b_index = mapping[a_index]
+        for mapping_number, group in enumerate(groups):
+            # It should not fail because the permutation result is only available for 2 parties, but let's be to safe.
+            assert 2 == len(group)
+            (_, a_index), (_, b_index) = sorted(group)
 
             # Choose the index in the new mapping (randomly)
             mapping_index = remaining_new_indexes[mapping_number]

--- a/backend/entityservice/tasks/run.py
+++ b/backend/entityservice/tasks/run.py
@@ -3,7 +3,7 @@ import psycopg2
 from entityservice.cache import progress as progress_cache
 from entityservice.cache.active_runs import set_run_state_active, is_run_missing
 from entityservice.database import DBConn, check_project_exists, get_run, get_run_state_for_update
-from entityservice.database import update_run_set_started, get_dataprovider_ids
+from entityservice.database import update_run_set_started
 from entityservice.errors import RunDeleted, ProjectDeleted
 from entityservice.tasks.base_task import TracedTask
 from entityservice.tasks.comparing import create_comparison_jobs

--- a/backend/entityservice/tasks/solver.py
+++ b/backend/entityservice/tasks/solver.py
@@ -5,7 +5,6 @@ from entityservice.async_worker import celery, logger
 from entityservice.settings import Config as config
 from entityservice.tasks.base_task import TracedTask
 from entityservice.tasks.permutation import save_and_permute
-from entityservice.utils import similarity_matrix_from_csv_bytes
 
 
 @celery.task(base=TracedTask, ignore_result=True, args_as_tags=('project_id', 'run_id'))

--- a/backend/entityservice/tests/conftest.py
+++ b/backend/entityservice/tests/conftest.py
@@ -4,8 +4,7 @@ import pytest
 import requests as requests_library
 import itertools
 
-from entityservice.tests.util import create_project_upload_fake_data, delete_project, temporary_blank_project, \
-    create_project_no_data
+from entityservice.tests.util import create_project_upload_fake_data, delete_project, create_project_no_data
 
 THROTTLE_SLEEP = 0.2
 
@@ -29,7 +28,7 @@ def requests():
 #
 # - pairs of dataset sizes
 # - overlap of the sizes
-# - result_type in ['mapping', 'similarity_scores', 'permutations']
+# - result_type for 2 parties in ['similarity_scores', 'permutations'] and for more parties in ['groups']
 # - threshold
 
 ENVVAR_NAME = 'ENTITY_SERVICE_RUN_SLOW_TESTS'
@@ -70,7 +69,7 @@ PROJECT_PARAMS_2P = tuple(
     itertools.product(SIZES_2P, OVERLAPS, ENCODING_SIZES))
 PROJECT_PARAMS_NP = tuple(
     itertools.product(SIZES_NP, OVERLAPS, ENCODING_SIZES))
-PROJECT_RESULT_TYPES_2P = ['mapping', 'similarity_scores', 'permutations']
+PROJECT_RESULT_TYPES_2P = ['similarity_scores', 'permutations']
 PROJECT_RESULT_TYPES_NP = ['groups']
 
 
@@ -102,14 +101,6 @@ def create_project_response(requests, size, overlap, result_type, encoding_size=
         'dp_responses': dp_responses
     })
     return project
-
-
-@pytest.fixture(scope='function', params=PROJECT_PARAMS_2P)
-def mapping_project(request, requests):
-    size, overlap, encoding_size = request.param
-    prj = create_project_response(requests, size, overlap, 'mapping', encoding_size)
-    yield prj
-    delete_project(requests, prj)
 
 
 @pytest.fixture(scope='function', params=PROJECT_PARAMS_2P)

--- a/backend/entityservice/tests/test_project_run_listing.py
+++ b/backend/entityservice/tests/test_project_run_listing.py
@@ -21,7 +21,7 @@ def test_list_run_invalid_auth(requests):
 
 
 def test_list_run_after_posting_runs(requests):
-    with temporary_blank_project(requests, result_type='mapping') as project:
+    with temporary_blank_project(requests, result_type='groups') as project:
 
         for i in range(1, 11):
             run_id = post_run(requests, project, 0.95)

--- a/backend/entityservice/tests/test_project_run_results.py
+++ b/backend/entityservice/tests/test_project_run_results.py
@@ -1,13 +1,4 @@
-from entityservice.tests.util import create_project_no_data, post_run, get_run_result, wait_approx_run_time
-
-
-def test_run_mapping_results(requests, mapping_project):
-    run_id = post_run(requests, mapping_project, 0.95)
-    wait_approx_run_time(mapping_project['size'])
-
-    result = get_run_result(requests, mapping_project, run_id, timeout=120)
-    assert 'mapping' in result
-    assert isinstance(result['mapping'], dict)
+from entityservice.tests.util import create_project_no_data, post_run, get_run_result
 
 
 def test_run_similarity_score_results(requests, similarity_scores_project, threshold):

--- a/backend/entityservice/tests/test_project_run_status.py
+++ b/backend/entityservice/tests/test_project_run_status.py
@@ -3,12 +3,17 @@ from entityservice.tests.util import post_run, get_run_status, is_run_status, \
     create_project_no_data, ensure_run_progressing
 
 
-def test_run_status_with_clks_2p(requests, mapping_project):
-    size = mapping_project['size']
-    ensure_run_progressing(requests, mapping_project, size)
+def test_permutations_run_status_with_clks_2p(requests, permutations_project):
+    size = permutations_project['size']
+    ensure_run_progressing(requests, permutations_project, size)
 
 
-def test_run_status_with_clks_np(requests, groups_project):
+def test_similarity_scores_run_status_with_clks_2p(requests, similarity_scores_project):
+    size = similarity_scores_project['size']
+    ensure_run_progressing(requests, similarity_scores_project, size)
+
+
+def test_groups_run_status_with_clks_np(requests, groups_project):
     size = groups_project['size']
     ensure_run_progressing(requests, groups_project, size)
 

--- a/backend/entityservice/tests/test_project_uploads.py
+++ b/backend/entityservice/tests/test_project_uploads.py
@@ -49,15 +49,7 @@ def test_project_binary_data_uploaded(requests, valid_project_params):
     run_id = post_run(requests, new_project_data, 0.99)
     result = get_run_result(requests, new_project_data, run_id, wait=True)
 
-    if valid_project_params['result_type'] == 'mapping':
-        assert 'mapping' in result
-
-        # Since we uploaded the same file it should have identified the
-        # same rows as matches
-        for i in range(1, 1000):
-            assert str(i) in result['mapping']
-            assert result['mapping'][str(i)] == str(i)
-    elif valid_project_params['result_type'] == 'groups':
+    if valid_project_params['result_type'] == 'groups':
         assert 'groups' in result
         groups = result['groups']
         assert len(groups) == 1000
@@ -101,10 +93,7 @@ def test_project_binary_data_upload_with_different_encoded_size(
 
     run_id = post_run(requests, new_project_data, 0.99)
     result = get_run_result(requests, new_project_data, run_id, wait=True)
-    if valid_project_params['result_type'] == 'mapping':
-        assert 'mapping' in result
-        assert result['mapping']['499'] == '0'
-    elif valid_project_params['result_type'] == 'groups':
+    if valid_project_params['result_type'] == 'groups':
         assert 'groups' in result
         groups = result['groups']
         groups_set = {frozenset(map(tuple, group)) for group in groups}
@@ -127,10 +116,7 @@ def test_project_json_data_upload_with_various_encoded_sizes(
 
     run_id = post_run(requests, new_project_data, 0.9)
     result = get_run_result(requests, new_project_data, run_id, wait=True)
-    if result_type == 'mapping':
-        assert 'mapping' in result
-        assert len(result['mapping']) >= 400
-    elif result_type == 'groups':
+    if result_type == 'groups':
         assert 'groups' in result
         # This is a pretty bad bound, but we're not testing the
         # accuracy.

--- a/backend/entityservice/tests/util.py
+++ b/backend/entityservice/tests/util.py
@@ -263,7 +263,6 @@ def wait_approx_run_time(size, assumed_rate=1_000_000):
     """
     number_comparisons = sum(
         size0 * size1 for size0, size1 in itertools.combinations(size, 2))
-    time.sleep(1)
     time.sleep(number_comparisons / assumed_rate)
 
 

--- a/backend/entityservice/tests/util.py
+++ b/backend/entityservice/tests/util.py
@@ -263,7 +263,7 @@ def wait_approx_run_time(size, assumed_rate=1_000_000):
     """
     number_comparisons = sum(
         size0 * size1 for size0, size1 in itertools.combinations(size, 2))
-    time.sleep(5)
+    time.sleep(1)
     time.sleep(number_comparisons / assumed_rate)
 
 

--- a/backend/entityservice/tests/util.py
+++ b/backend/entityservice/tests/util.py
@@ -126,7 +126,7 @@ def get_project_description(requests, new_project_data):
 
 
 def create_project_no_data(requests,
-                           result_type='mapping', number_parties=None):
+                           result_type='groups', number_parties=None):
     number_parties_param = (
         {} if number_parties is None else {'number_parties': number_parties})
     new_project_response = requests.post(url + '/projects',
@@ -141,7 +141,7 @@ def create_project_no_data(requests,
 
 
 @contextmanager
-def temporary_blank_project(requests, result_type='mapping'):
+def temporary_blank_project(requests, result_type='groups'):
     # Code to acquire resource, e.g.:
     project = create_project_no_data(requests, result_type)
     yield project
@@ -152,7 +152,7 @@ def temporary_blank_project(requests, result_type='mapping'):
 def create_project_upload_fake_data(
         requests,
         sizes, overlap=0.75,
-        result_type='mapping', encoding_size=128):
+        result_type='groups', encoding_size=128):
     data = generate_overlapping_clk_data(
         sizes, overlap=overlap, encoding_size=encoding_size)
     new_project_data, json_responses = create_project_upload_data(
@@ -162,7 +162,7 @@ def create_project_upload_fake_data(
 
 
 def create_project_upload_data(
-        requests, data, result_type='mapping', binary=False, hash_size=None):
+        requests, data, result_type='groups', binary=False, hash_size=None):
     if binary and hash_size is None:
         raise ValueError('binary mode must specify a hash_size')
 

--- a/backend/entityservice/views/auth_checks.py
+++ b/backend/entityservice/views/auth_checks.py
@@ -90,7 +90,7 @@ def get_authorization_token_type_or_abort(project_id, token):
     # that might mean the caller is not authorized.
     with DBConn() as conn:
         result_type = get_project_column(conn, project_id, 'result_type')
-    if result_type in {'mapping', 'similarity_scores'} and token_type == 'receipt_token':
+    if result_type in {'groups', 'similarity_scores'} and token_type == 'receipt_token':
         logger.info("Caller provided receipt token to get results")
         safe_fail_request(403, message=INVALID_ACCESS_MSG)
     return token_type

--- a/backend/entityservice/views/project.py
+++ b/backend/entityservice/views/project.py
@@ -208,7 +208,7 @@ def authorise_get_request(project_id):
         project_object = db.get_project(dbinstance, project_id)
     logger.info("Checking credentials")
     result_type = project_object['result_type']
-    if result_type in {'mapping', 'similarity_scores', 'groups'}:
+    if result_type in {'groups', 'similarity_scores'}:
         # Check the caller has a valid results token if we are including results
         abort_if_invalid_results_token(project_id, auth_header)
     elif result_type == 'permutations':

--- a/backend/entityservice/views/run/results.py
+++ b/backend/entityservice/views/run/results.py
@@ -39,12 +39,7 @@ def get_result(dbinstance, project_id, run_id, token):
     result_type = db.get_project_column(dbinstance, project_id, 'result_type')
     auth_token_type = get_authorization_token_type_or_abort(project_id, token)
 
-    if result_type == 'mapping':
-        logger.info("Mapping result being returned")
-        result = db.get_run_result(dbinstance, run_id)
-        return {"mapping": result}
-
-    elif result_type == 'groups':
+    if result_type == 'groups':
         logger.info("Groups result being returned")
         result = db.get_run_result(dbinstance, run_id)
         return {"groups": result}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,12 @@ Changelog
 Next Version
 ------------
 
+- ``matching`` output type has been removed as redundant with the ``groups`` output with 2 parties. (#458)
 
+Breaking Change
+~~~~~~~~~~~~~~~
 
+- ``matching`` output type is not available anymore. (#458)
 
 Version 1.12.0
 --------------

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -128,22 +128,6 @@ A score of ``1.0`` means the CLKs were identical. Threshold values are usually b
         Comparing two data sets each containing 1 million records with a threshold
         of ``0.0`` will return 1 trillion results (``1e+12``).
 
-Direct Mapping Table (Deprecated for Groups Result)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The direct mapping takes the similarity scores and simply assigns the highest scores as links.
-
-The links are exposed as a lookup table using indices from the two organizations::
-
-    {
-        index_a: index_b,
-        ...
-    }
-
-
-The ``result_token`` (generated when creating the mapping) is required to retrieve the results. The
-``result_type`` should be set to ``"mapping"``.
-
 Groups Result
 ~~~~~~~~~~~~~
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,7 @@ Development
    :maxdepth: 1
 
    changelog
+   devops
    future
    releasing
 
@@ -63,31 +64,6 @@ The run info ``HASH`` stores:
   ``{active, complete, deleted}``. See
   ``backend/entityservice/cache/active_runs.py`` for implementation.
 
-
-Continuous Integration Testing
-------------------------------
-
-We test the service using `Jenkins <https://jenkins.io/>`__. Every pull request gets deployed in the
-local configuration using Docker Compose, as well as in the production deployment to kubernetes.
-
-At a high level the testing covers:
-
-- building the docker containers
-- deploying using Docker Compose
-- testing the tutorial notebooks don't error
-- running the integration tests against the local deployment
-- running a benchmark suite against the local deployment
-- building and packaging the documentation
-- publishing the containers to quay.io
-- deploying to kubernetes
-- running the integration tests against the kubernetes deployment
-
-
-All of this is orchestrated using the jenkins pipeline script at ``Jenkinsfile.groovy``. There is one custom
-library which is `n1-pipeline <https://github.com/n1analytics/n1-pipeline/>`__ a collection of helpers that
-we created for common jenkins tasks.
-
-The integration tests currently take around 30 minutes.
 
 Testing Local Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/future.rst
+++ b/docs/future.rst
@@ -18,7 +18,7 @@ Road map for the entity service
 - optimise anonlink memory management and C++ code
 
 Bigger Projects
-- consider more than 2 organizations participating in one mapping
+
 - GPU implementation of core similarity scoring
 - somewhat homomorphic encryption could be used for similarity score
 - consider allowing users to upload raw PII

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -10,16 +10,16 @@ be linked.
 Considerations for each output type
 -----------------------------------
 
-Direct Mapping Table
-~~~~~~~~~~~~~~~~~~~~
+Groups
+~~~~~~
 
 The default output of the Entity Service comprises a list of edges - connections between rows in
-dataset A to rows in dataset B. This assumes at most a 1-1 corrospondence - each entity will
+the different datasets. This assumes at most a 1-1 correspondence - each entity will
 only be present in zero or one edge.
 
 This output is only available to the client who created the mapping,
 but it is worth highlighting that it does (by design) leak information about the intersection of the
-two sets of entities.
+sets of entities.
 
 **Knowledge about set intersection**
 This output contains information about which particular entities are shared, and which are not.
@@ -81,7 +81,7 @@ There are three different types of tokens:
 
 - *update_token*: required to upload a party's CLKs.
 - *result_token*: required to access the result of the entity resolution process. This is, depending on the
-  :ref:`output type <result-types>`, either similarity scores, a direct mapping table, or a mask.
+  :ref:`output type <result-types>`, either similarity scores, a group output, or a mask.
 - *receipt-token*: this token is returned to either party after uploading their respective CLKs. With this
   *receipt-token* they can then access their respective permutations, if the output type of the mapping is set to
   permutation and mask.

--- a/docs/tutorial/Record Linkage API.ipynb
+++ b/docs/tutorial/Record Linkage API.ipynb
@@ -70,10 +70,10 @@
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
       "Testing anonlink-entity-service hosted at https://testing.es.data61.xyz/api/v1/\n"
-     ]
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
@@ -93,13 +93,11 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'project_count': 2278, 'rate': 3863861, 'status': 'ok'}"
-      ]
+      "text/plain": "{'project_count': 7871, 'rate': 301990, 'status': 'ok'}"
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 3
     }
    ],
    "source": [
@@ -150,7 +148,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "with open('a.csv', 'w') as a_csv:\n",
@@ -237,11 +239,18 @@
    "outputs": [
     {
      "name": "stderr",
-     "output_type": "stream",
      "text": [
-      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:02<00:00, 1.78kclk/s, mean=645, std=43.8]\n",
-      "generating CLKs: 100%|██████████| 5.00k/5.00k [00:02<00:00, 1.35kclk/s, mean=634, std=50.3]\n"
-     ]
+      "\rgenerating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]",
+      "\rgenerating CLKs:   4%|▍         | 200/5.00k [00:00<00:07, 682clk/s, mean=643, std=44.8]",
+      "\rgenerating CLKs:  52%|█████▏    | 2.60k/5.00k [00:00<00:02, 959clk/s, mean=643, std=45.7]",
+      "\rgenerating CLKs: 100%|██████████| 5.00k/5.00k [00:00<00:00, 9.71kclk/s, mean=644, std=45.4]",
+      "\n\rgenerating CLKs:   0%|          | 0.00/5.00k [00:00<?, ?clk/s, mean=0, std=0]",
+      "\rgenerating CLKs:   4%|▍         | 200/5.00k [00:00<00:04, 1.12kclk/s, mean=625, std=57.3]",
+      "\rgenerating CLKs:  52%|█████▏    | 2.60k/5.00k [00:00<00:01, 1.56kclk/s, mean=632, std=52.9]",
+      "\rgenerating CLKs: 100%|██████████| 5.00k/5.00k [00:00<00:00, 12.4kclk/s, mean=632, std=53]  ",
+      "\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
@@ -275,22 +284,17 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'project_id': 'e98ababc1a02a4057a13b39c846e9f219acf71bd0a4143c7',\n",
-       " 'result_token': '693c423c0c021f92a9f7b1658ef8f19beaa7b9c1b27ea22c',\n",
-       " 'update_tokens': ['57401d6c0edfa78abf3bd4a87936159f8c974f93dc352d21',\n",
-       "  '8c44139db950ca88f58f18d18e219f001fa105543a7b25e6']}"
-      ]
+      "text/plain": "{'project_id': '0989ebe812ab245b3639c2ffae0ac82a9e6efb97d32f3a1f',\n 'result_token': '29687113baf41a7947d049e52f7804ca77fbba0abd243931',\n 'update_tokens': ['0d2321c208a03af044074ac4131ebc795ecb5516749b34d1',\n  '55cb5f601fb982ae33dbe4ba27c625fd32f37b08ae410dff']}"
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 9
     }
    ],
    "source": [
     "project_spec = {\n",
     "  \"schema\": {},\n",
-    "  \"result_type\": \"mapping\",\n",
+    "  \"result_type\": \"groups\",\n",
     "  \"number_parties\": 2,\n",
     "  \"name\": \"API Tutorial Test\"\n",
     "}\n",
@@ -315,24 +319,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'error': False,\n",
-       " 'name': 'API Tutorial Test',\n",
-       " 'notes': '',\n",
-       " 'number_parties': 2,\n",
-       " 'parties_contributed': 0,\n",
-       " 'project_id': 'e98ababc1a02a4057a13b39c846e9f219acf71bd0a4143c7',\n",
-       " 'result_type': 'mapping',\n",
-       " 'schema': {}}"
-      ]
+      "text/plain": "{'error': False,\n 'name': 'API Tutorial Test',\n 'notes': '',\n 'number_parties': 2,\n 'parties_contributed': 0,\n 'project_id': '0989ebe812ab245b3639c2ffae0ac82a9e6efb97d32f3a1f',\n 'result_type': 'groups',\n 'schema': {}}"
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 10
     }
    ],
    "source": [
@@ -360,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -377,8 +376,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "b_response = requests.post(\n",
@@ -410,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -430,8 +433,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [],
    "source": [
     "run_id = run_response['run_id']"
@@ -446,26 +453,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'current_stage': {'description': 'compute similarity scores',\n",
-       "  'number': 2,\n",
-       "  'progress': {'absolute': 25000000,\n",
-       "   'description': 'number of already computed similarity scores',\n",
-       "   'relative': 1.0}},\n",
-       " 'stages': 3,\n",
-       " 'state': 'running',\n",
-       " 'time_added': '2019-04-30T12:18:44.633541+00:00',\n",
-       " 'time_started': '2019-04-30T12:18:44.778142+00:00'}"
-      ]
+      "text/plain": "{'current_stage': {'description': 'compute output', 'number': 3},\n 'stages': 3,\n 'state': 'completed',\n 'time_added': '2019-11-01T02:39:19.310376+00:00',\n 'time_completed': '2019-11-01T02:39:20.389791+00:00',\n 'time_started': '2019-11-01T02:39:19.336674+00:00'}"
      },
-     "execution_count": 23,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 15
     }
    ],
    "source": [
@@ -490,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -499,11 +500,10 @@
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "State: completed\n",
-      "Stage (3/3): compute output\n"
-     ]
+      "State: completed\nStage (3/3): compute output\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
@@ -515,9 +515,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "metadata": {
-    "pycharm": {}
+    "pycharm": {
+     "is_executing": false
+    }
    },
    "outputs": [],
    "source": [
@@ -539,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 21,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -548,25 +550,16 @@
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "a[0] maps to b[1449]\n",
-      "a[1] maps to b[2750]\n",
-      "a[2] maps to b[4656]\n",
-      "a[3] maps to b[4119]\n",
-      "a[4] maps to b[3306]\n",
-      "a[5] maps to b[2305]\n",
-      "a[6] maps to b[3944]\n",
-      "a[7] maps to b[992]\n",
-      "a[8] maps to b[4612]\n",
-      "a[9] maps to b[3629]\n",
-      "...\n"
-     ]
+      "a[1859] maps to b[3906]\na[950] maps to b[3115]\na[3466] maps to b[3210]\na[1006] maps to b[3452]\na[2325] maps to b[3248]\na[2291] maps to b[687]\na[2144] maps to b[1101]\na[1768] maps to b[3890]\na[1307] maps to b[2441]\na[2932] maps to b[3006]\n...\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
     "for i in range(10):\n",
-    "    print(\"a[{}] maps to b[{}]\".format(i, data['mapping'][str(i)]))\n",
+    "    ((_, a_index), (_, b_index)) = sorted(data['groups'][i])\n",
+    "    print(\"a[{}] maps to b[{}]\".format(a_index, b_index))\n",
     "print(\"...\")"
    ]
   },
@@ -581,7 +574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 19,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -590,17 +583,15 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "4853"
-      ]
+      "text/plain": "4851"
      },
-     "execution_count": 31,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 19
     }
    ],
    "source": [
-    "len(data['mapping'])"
+    "len(data['groups'])"
    ]
   },
   {
@@ -614,18 +605,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "<Response [403]>"
-      ]
+      "text/plain": "<Response [204]>"
      },
-     "execution_count": 44,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 20
     }
    ],
    "source": [
@@ -663,10 +656,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },


### PR DESCRIPTION
The goal of this PR is to remove the `mapping` output type from the entity-service. The `mapping` output type is indeed redundant with the `groups` output type for 2 parties, however, the output representation is slightly different.

Few notes:
 - the documentation is horrible to update as there are a lot of things out of date.
 - the tutorial python notebooks are not manageable from here: we are mainly testing clkhash
 - most of the docs requires to have the entity-service already available (they point to `testing.es.data61.xyz`) which makes them impossible to keep up to date in the same PR as the one modifying the service