### PR TITLE
Fix starting runs

### DIFF
--- a/backend/entityservice/database/insertions.py
+++ b/backend/entityservice/database/insertions.py
@@ -215,17 +215,6 @@ def update_run_mark_failure(conn, run_id):
         cur.execute(sql_query, [run_id])
 
 
-def update_run_mark_queued(db, run_id):
-    with db.cursor() as cur:
-        sql_query = """
-            UPDATE runs SET
-              state = 'queued'
-            WHERE
-              run_id = %s
-            """
-        cur.execute(sql_query, [run_id])
-
-
 def mark_project_deleted(db, project_id):
     with db.cursor() as cur:
         sql_query = """
@@ -263,7 +252,7 @@ def get_created_runs_and_queue(db, project_id):
             UPDATE runs SET
               state = 'queued'
             WHERE
-              state IN ('created', 'queued') AND project = %s
+              state = 'created' AND project = %s
             RETURNING
               run_id;
         """

--- a/backend/entityservice/views/run/list.py
+++ b/backend/entityservice/views/run/list.py
@@ -3,7 +3,7 @@ from structlog import get_logger
 
 from entityservice import database as db
 from entityservice.tasks import check_for_executable_runs
-from entityservice.database import get_runs, update_run_mark_queued
+from entityservice.database import get_runs
 from entityservice.models.run import Run
 from entityservice.utils import safe_fail_request
 from entityservice.views.auth_checks import abort_if_project_doesnt_exist, abort_if_invalid_results_token, \
@@ -44,23 +44,11 @@ def post(project_id, run):
 
     with db.DBConn() as db_conn:
         run_model.save(db_conn)
-        project_object = db.get_project(db_conn, project_id)
-        parties_contributed = db.get_number_parties_uploaded(db_conn, project_id)
-        ready_to_run = parties_contributed == project_object['parties']
-        log.debug("Expecting {} parties to upload data. Have received {}".format(
-            project_object['parties'], parties_contributed
-        ))
-        if ready_to_run:
-            log.info("Scheduling task to carry out all runs for project {} now".format(project_id))
-            update_run_mark_queued(db_conn, run_model.run_id)
-        else:
-            log.info("Task queued but won't start until CLKs are all uploaded")
 
-    if ready_to_run:
-        span = g.flask_tracer.get_span()
-        span.set_tag("run_id", run_model.run_id)
-        span.set_tag("project_id", run_model.project_id)
-        check_for_executable_runs.delay(project_id, serialize_span(span))
+    span = g.flask_tracer.get_span()
+    span.set_tag("run_id", run_model.run_id)
+    span.set_tag("project_id", run_model.project_id)
+    check_for_executable_runs.delay(project_id, serialize_span(span))
     return RunDescription().dump(run_model), 201
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ pytest==5.1.3
 pytest-xdist==1.29.0
 PyYAML==5.1
 redis==3.2.1
-requests==2.21.0
+requests==2.22.0
 setproctitle==1.1.10 # used by celery to change process name
 structlog==18.2.0
 tenacity==5.1.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,11 @@ Changelog
 Next Version
 ------------
 
+- fixed bug where invalid state changes could occur when starting a run (#459)
 
+- Update dependencies:
+
+    - requests from 2.21.0 to 2.22.0 (#459)
 
 
 Version 1.12.0
@@ -54,7 +58,7 @@ Version 1.12.0
 - Update dependencies:
 
    - anonlink to v0.12.5. (#423)
-   - redis to from 3.2.0 to 3.2.1 (#415)
+   - redis from 3.2.0 to 3.2.1 (#415)
    - alpine from 3.9 to 3.10.1 (#404)
 
 - Add some release documentation. (#455)


### PR DESCRIPTION
It all started with this strange failure in a clkhash test:
```
State: queued
Stage (1/3): waiting for CLKs
Progress: 100.00%
State: queued
Stage (1/3): waiting for CLKs
Progress: 100.00%
State: queued
Stage (2/3): compute similarity scores
State: running
Stage (3/3): compute output
State: running
Stage (4/3): there is no description for this stage
```
It turns out, that the entity service is naughty.

The problem is around the detection of the race condition to start a run twice.
The idea is that a run's state is set to `created` after creation, and only once all data provider have uploaded the necessary clks, the run state gets promoted to `queued` and, consequently, the run execution gets started.

However, some naughty code in `views/run/list.py:post` did some premature clk checking and run state changing. After all that, it would still call the `check_for_executable_runs` task, which will then do exactly the same again. 
Now, as we previously "fixed" the `get_created_runs_and_queue` by allowing to return runs that are either `created` OR `queued`, together with the fact that `check_for_executable_runs` can be called twice almost in parallel, led to double queuing of the run and double stage progressing.

To stop all this nonsense, I propose to not include run logic in the views of ngnix. If we always call the same task as entrypoint (`check_for_executable_runs`), it will, most likely, keep as saner for longer. Hopefully.
