### PR TITLE
Remove redundant tests

### DIFF
--- a/backend/entityservice/tests/test_project_run_description.py
+++ b/backend/entityservice/tests/test_project_run_description.py
@@ -1,30 +1,5 @@
-import pytest
-from entityservice.tests.config import url
 from entityservice.tests.util import create_project_upload_fake_data, post_run, get_run
 
 
 def test_run_description_missing_run(requests, project):
-    _ = get_run(requests, project, 'invalid', expected_status = 403)
-
-
-def test_run_description_no_data(requests, project):
-    run_id = post_run(requests, project, 0.95)
-    run = get_run(requests, project, run_id)
-
-    assert 'run_id' in run
-    assert 'notes' in run
-    assert 'threshold' in run
-
-
-def test_run_description(requests, result_type_number_parties):
-    THRESHOLD = .98
-
-    result_type, number_parties = result_type_number_parties
-    project, _ = create_project_upload_fake_data(
-        requests, [100] * number_parties, overlap=0.5, result_type=result_type)
-    run_id = post_run(requests, project, THRESHOLD)
-    run = get_run(requests, project, run_id)
-
-    assert 'run_id' in run
-    assert 'notes' in run
-    assert run['threshold'] == THRESHOLD
+    _ = get_run(requests, project, 'invalid', expected_status=403)

--- a/backend/entityservice/tests/test_project_run_status.py
+++ b/backend/entityservice/tests/test_project_run_status.py
@@ -1,21 +1,6 @@
 
 from entityservice.tests.util import post_run, get_run_status, is_run_status, \
-    create_project_no_data, ensure_run_progressing
-
-
-def test_permutations_run_status_with_clks_2p(requests, permutations_project):
-    size = permutations_project['size']
-    ensure_run_progressing(requests, permutations_project, size)
-
-
-def test_similarity_scores_run_status_with_clks_2p(requests, similarity_scores_project):
-    size = similarity_scores_project['size']
-    ensure_run_progressing(requests, similarity_scores_project, size)
-
-
-def test_groups_run_status_with_clks_np(requests, groups_project):
-    size = groups_project['size']
-    ensure_run_progressing(requests, groups_project, size)
+    create_project_no_data
 
 
 def test_run_status_without_clks(requests):

--- a/backend/entityservice/tests/util.py
+++ b/backend/entityservice/tests/util.py
@@ -234,7 +234,7 @@ def wait_for_run(requests, project, run_id, ok_statuses, result_token=None, time
     Poll project/run_id until its status is one of the ok_statuses. Raise a
     TimeoutError if we've waited more than timeout seconds.
     It also checks that the status are progressing normally, using the checks implemented in
-    `has_not_progressed_invalidly`.
+    `has_progressed_validly`.
     """
     start_time = time.time()
     old_status = None


### PR DESCRIPTION
This PR will close #457 
Currently, the entity-service is trying to do unit tests in an end to end way. For example, the removed tests were about testing the run endpoint by creating full runs.
These full runs are already created in a number of other tests (e.g. the ones where we check the validity of the output of a run).
So in this PR, I removed some tests about intermediary results such as checking that a run is progressing normally and testing the run endpoint.

However, this is slightly against the tests visions where each test describe what it is "unit" testing. In the approach I started, we run the whole end to end pipeline and on the way test each part. 

But from 327 tests running in 7m 40s on my machine with a simple local deployment on the service, the PR reduced the number of tests to 283 ran in 6m 35s with the same deployment.