### PR TITLE
Install wheel and update base docker image.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.10.3
 
 EXPOSE 8000
 ADD requirements.txt /var/www/requirements.txt
@@ -14,7 +14,7 @@ WORKDIR /var/www
 RUN apk add --no-cache python3 libstdc++ mpc1-dev yajl libpq && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     apk add --no-cache --virtual .build-deps g++ python3-dev yajl-dev postgresql-dev libffi-dev gmp-dev mpfr-dev wait4ports && \
-    pip3 install --upgrade pip setuptools && \
+    pip3 install --upgrade pip setuptools wheel && \
     pip3 install --upgrade -r requirements.txt && \
     apk del --no-cache .build-deps && \
     rm -fr /tmp/* /var/cache/apk/* /root/.cache/pip


### PR DESCRIPTION
Wheel has become required to install anonlink. Not sure why...
At the same time, update docker alpine base image.
closes #468
This issue is currently blocking any other builds as they cannot build the anonlink-app image.