### PR TITLE
Feature create blocking project

### DIFF
--- a/backend/entityservice/api_def/swagger.yaml
+++ b/backend/entityservice/api_def/swagger.yaml
@@ -764,6 +764,11 @@ definitions:
       notes:
         description: Any free text to store with this project.
         type: string
+      uses_blocking:
+        type: boolean
+        description: |
+          Whether the linkage uses blocking. This requires that the CLKs are uploaded with corresponding blocking
+          information.
     required:
       - schema
       - result_type

--- a/backend/entityservice/database/insertions.py
+++ b/backend/entityservice/database/insertions.py
@@ -5,17 +5,17 @@ from entityservice.database.util import execute_returning_id, logger, query_db
 from entityservice.errors import RunDeleted
 
 
-def insert_new_project(cur, result_type, schema, access_token, project_id, num_parties, name, notes):
+def insert_new_project(cur, result_type, schema, access_token, project_id, num_parties, name, notes, uses_blocking):
     sql_query = """
         INSERT INTO projects
-        (project_id, name, access_token, schema, notes, parties, result_type)
+        (project_id, name, access_token, schema, notes, parties, result_type, uses_blocking)
         VALUES
-        (%s, %s, %s, %s, %s, %s, %s)
+        (%s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING project_id;
         """
     return execute_returning_id(cur, sql_query,
                                 [project_id, name, access_token, psycopg2.extras.Json(schema), notes, num_parties,
-                                 result_type])
+                                 result_type, uses_blocking])
 
 
 def insert_new_run(db, run_id, project_id, threshold, name, type, notes=''):

--- a/backend/entityservice/init-db-schema.sql
+++ b/backend/entityservice/init-db-schema.sql
@@ -41,7 +41,9 @@ CREATE TABLE projects (
 
   result_type         MAPPINGRESULT NOT NULL,
 
-  marked_for_deletion boolean   DEFAULT FALSE
+  marked_for_deletion boolean   DEFAULT FALSE,
+
+  uses_blocking       boolean   DEFAULT FALSE
 );
 
 CREATE TYPE RUNSTATE AS ENUM (

--- a/backend/entityservice/models/project.py
+++ b/backend/entityservice/models/project.py
@@ -20,13 +20,14 @@ class Project(object):
 
     Exists before insertion into the database.
     """
-    def __init__(self, result_type, schema, name, notes, parties):
+    def __init__(self, result_type, schema, name, notes, parties, uses_blocking):
         logger.debug("Creating project codes")
         self.result_type = result_type
         self.schema = schema
         self.name = name
         self.notes = notes
         self.number_parties = parties
+        self.uses_blocking = uses_blocking
 
         self.project_id = generate_code()
         logger.debug("Generated project code", pid=self.project_id)
@@ -60,12 +61,13 @@ class Project(object):
         name = data.get('name', '')
         notes = data.get('notes', '')
         parties = data.get('number_parties', 2)
+        uses_blocking = data.get('uses_blocking', False)
 
         if parties > 2 and result_type != 'groups':
             raise InvalidProjectParametersException(
                 "Multi-party linkage requires result type 'groups'.")            
 
-        return Project(result_type, schema, name, notes, parties)
+        return Project(result_type, schema, name, notes, parties, uses_blocking)
 
     def save(self, conn):
         with conn.cursor() as cur:
@@ -77,7 +79,8 @@ class Project(object):
                                                self.project_id,
                                                self.number_parties,
                                                self.name,
-                                               self.notes
+                                               self.notes,
+                                               self.uses_blocking
                                                )
 
             logger.debug("New project created in DB")

--- a/backend/entityservice/tests/test_project.py
+++ b/backend/entityservice/tests/test_project.py
@@ -20,19 +20,28 @@ def _check_new_project_response_fields(new_project_data,
 
 
 def test_simple_create_project(requests, valid_project_params):
-    project_name = 'a test project'
-    project_description = 'created by unittest'
+    for uses_blocking in (True, False):
+        name = 'a test project'
+        description = 'created by unittest'
 
-    project_response = requests.post(url + '/projects', json={
-        'schema': {},
-        'name': project_name,
-        'notes': project_description,
-        **valid_project_params
-    })
+        project_response = requests.post(url + '/projects', json={
+            'schema': {},
+            'name': name,
+            'notes': description,
+            'uses_blocking': uses_blocking,
+            **valid_project_params
+        })
 
-    assert project_response.status_code == 201
-    new_project_data = project_response.json()
-    _check_new_project_response_fields(new_project_data, valid_project_params)
+        assert project_response.status_code == 201
+        new_project_data = project_response.json()
+        _check_new_project_response_fields(new_project_data, valid_project_params)
+        project_description = requests.get(
+            url + '/projects/{}'.format(new_project_data['project_id']),
+            headers={'Authorization': new_project_data['result_token']}
+        ).json()
+        assert project_description['name'] == name
+        assert project_description['notes'] == description
+        assert project_description['uses_blocking'] is uses_blocking
 
 
 def test_create_then_delete_no_auth(requests, valid_project_params):

--- a/backend/entityservice/views/serialization.py
+++ b/backend/entityservice/views/serialization.py
@@ -20,6 +20,7 @@ class ProjectDescription(Schema):
     name = fields.String()
     notes = fields.String()
     error = fields.Boolean()
+    uses_blocking = fields.Boolean()
 
 
 class NewProjectResponse(Schema):


### PR DESCRIPTION
This historic PR marks the beginning of blocking support in the entity service.

I added the flag 'uses_blocking' to the project. This can be set at creation, and will be reported in the ProjectDescription. Internally, this is stored as a flag in the project table in the database.

The idea is that all following actions will consult the DB to decide how to handle data upload, candidate creation and solving...