### PR TITLE
Update redis and minio chart versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,6 +194,7 @@ stages:
         inputs:
           action: 'bake'
           helmChart: 'deployment/entity-service'
+          namespace: $(NAMESPACE)
           releaseName: $(DEPLOYMENT)
           overrides: |
             api.app.debug:true

--- a/deployment/entity-service/requirements.yaml
+++ b/deployment/entity-service/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.redis
   - name: minio
-    version: 1.6.2
+    version: 5.0.6
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.minio
   - name: postgresql

--- a/deployment/entity-service/requirements.yaml
+++ b/deployment/entity-service/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: redis-ha
-    version: 3.0.3
+    version: 4.3.3
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.redis
   - name: minio

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
   {{ end }}
   # MINIO_ACCESS_KEY provided as a secret
   # MINIO_SECRET_KEY provided as a secret
-  MINIO_BUCKET: {{ required "minio.bucket is required." .Values.minio.bucket | quote }}
+  MINIO_BUCKET: {{ required "minio.defaultBucket.name is required." .Values.minio.defaultBucket.name | quote }}
 
   {{ if .Values.provision.postgresql }}
   DATABASE_SERVER: {{ .Release.Name }}-{{ required "postgresql.nameOverride is required." .Values.postgresql.nameOverride }}

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -241,8 +241,8 @@ global:
     postgresqlPassword: "examplePostgresPassword"
 
 
-## In this section, we are not installing any redis pods. The main goal is to get configuration values for the
-## other services.
+## In this section, we are not installing Redis. The main goal is to define configuration values for
+## other services that need to access Redis.
 redis:
   ## Note the `server` options are ignored if provisioning redis
   ## using this chart.
@@ -290,7 +290,7 @@ minio:
   ## Configure the object storage
   ## https://github.com/helm/charts/blob/master/stable/minio/values.yaml
 
-  ## Access credentials for the object store
+  ## Default access credentials for the object store
   accessKey: "exampleMinioAccessKey"
   secretKey: "exampleMinioSecretKet"
 
@@ -298,10 +298,11 @@ minio:
   ## if provisioning minio during deployment.
   server: "s3.amazonaws.com"
 
-  bucket: "example-bucket"
+  defaultBucket:
+    enabled: true
+    name: "anonlink"
 
   ## Settings for deploying standalone object store
-  ## https://github.com/kubernetes/charts/tree/master/stable/minio#configuration
   ## Can distribute the object store across multiple nodes.
   mode: "standalone"
   service.type: "ClusterIP"
@@ -309,13 +310,28 @@ minio:
     enabled: false
     size: 50Gi
     storageClass: "default"
+
+  metrics:
+    serviceMonitor:
+      enabled: false
+      #additionalLabels: {}
+      #namespace: nil
+
+  # If you'd like to expose the MinIO object store
+  ingress:
+    enabled: false
+    #labels: {}
+    #annotations: {}
+    #hosts: []
+    #tls: []
+
   nameOverride: "minio"
   
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:
     requests:
       memory: 256Mi
-      cpu: 250m
+      cpu: 100m
     limits:
       memory: 5Gi
 

--- a/docs/tutorial/cli.rst
+++ b/docs/tutorial/cli.rst
@@ -39,13 +39,13 @@ Process the personally identifying data into :ref:`cryptographic-longterm-keys`:
 Now to interact with an Entity Service. First check that the service is healthy and responds to
 a status check::
 
-    $ clkutil status --server https://testing.es.data61.xyz
+    $ clkutil status --server https://anonlink.easd.data61.xyz
     {"rate": 53129, "status": "ok", "project_count": 1410}
 
 Then create a new linkage project and set the output type (to ``mapping``)::
 
     $ clkutil create-project \
-        --server https://testing.es.data61.xyz \
+        --server https://anonlink.easd.data61.xyz \
         --type mapping \
         --schema schema.json \
         --output credentials.json
@@ -65,13 +65,13 @@ The contents is two upload tokens and a result token::
 These credentials get substituted in the following commands. Each CLK dataset
 gets uploaded to the Entity Service::
 
-    $ clkutil upload --server https://testing.es.data61.xyz \
+    $ clkutil upload --server https://anonlink.easd.data61.xyz \
                     --apikey 21d4c9249e1c70ac30f9ce03893983c493d7e90574980e55 \
                     --project 809b12c7e141837c3a15be758b016d5a7826d90574f36e74 \
                     alice-hashed.json
     {"receipt_token": "05ac237462d86bc3e2232ae3db71d9ae1b9e99afe840ee5a", "message": "Updated"}
 
-    $ clkutil upload --server https://testing.es.data61.xyz \
+    $ clkutil upload --server https://anonlink.easd.data61.xyz \
                     --apikey 3ad6ae9028c09fcbc7fbca36d19743294bfaf215f1464905 \
                     --project 809b12c7e141837c3a15be758b016d5a7826d90574f36e74 \
                     bob-hashed.json
@@ -80,7 +80,7 @@ gets uploaded to the Entity Service::
 Now we can compute mappings using various thresholds. For example to only see relationships where the
 similarity is above ``0.9``::
 
-    $ clkutil create --server https://testing.es.data61.xyz \
+    $ clkutil create --server https://anonlink.easd.data61.xyz \
                      --apikey 230a303b05dfd186be87fa65bf7b0970fb786497834910d1 \
                      --project 809b12c7e141837c3a15be758b016d5a7826d90574f36e74 \
                      --name "Tutorial mapping run" \
@@ -91,7 +91,7 @@ similarity is above ``0.9``::
 After a small delay the mapping will have been computed and we can use ``clkutil`` to retrieve the
 results::
 
-    $ clkutil results --server https://testing.es.data61.xyz \
+    $ clkutil results --server https://anonlink.easd.data61.xyz \
                     --apikey  230a303b05dfd186be87fa65bf7b0970fb786497834910d1 \
                     --project 809b12c7e141837c3a15be758b016d5a7826d90574f36e74 \
                     --run 31a6d3c775151a877dcac625b4b91a6659317046ea45ad11


### PR DESCRIPTION
We recently noticed an issue with redis-ha not being "highly available" on our small test kubernetes cluster during cluster scaling events.

Before digging into it too much this PR brings our minio and redis chart dependencies up to date.