### PR TITLE
Skip build in bash if azure isn't playing along

### DIFF
--- a/.azurePipeline/templateDockerBuildPush.yml
+++ b/.azurePipeline/templateDockerBuildPush.yml
@@ -54,12 +54,16 @@ jobs:
         docker login -u $(dockerHubId) -p $(dockerHubPassword)
       displayName: 'Dockerhub login'
     - script: |
-        if [[ -z "${{ parameters.dockerFilePath }}" ]]; then
-          docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) $(DOCKER_BUILD_ARGS) ${{ parameters.folder }}
+        if [[ "$SKIP" == "False" ]]; then
+            if [[ -z "${{ parameters.dockerFilePath }}" ]]; then
+              docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) $(DOCKER_BUILD_ARGS) ${{ parameters.folder }}
+            else
+              docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) -f ${{ parameters.dockerFilePath }} $(DOCKER_BUILD_ARGS) ${{ parameters.folder }}
+            fi
+            docker push ${{ parameters.imageName }}:$(DOCKER_TAG)
         else
-          docker build -t ${{ parameters.imageName }}:$(DOCKER_TAG) -f ${{ parameters.dockerFilePath }} $(DOCKER_BUILD_ARGS) ${{ parameters.folder }}
+            echo "Skipping build"
         fi
-        docker push ${{ parameters.imageName }}:$(DOCKER_TAG)
       displayName: 'Build and push docker image'
 
 # Updated from the documentation https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
       dependsOn: HashBaseDependencies
       imageName: data61/anonlink-app
       # this part is still todo automated
-      dockerBuildArgs: "--build-arg VERSION=02a973ce02c96d24376c5770c0426ccb0958a0d59136a4f2fc11c8666c43062a"
+      dockerBuildArgs: "--build-arg VERSION=ed0be6ee130ec505b2a65af26ba570e1033ffb7e0cc6b27b6a8520df94f65d20"
       #dockerBuildArgs: "--build-arg VERSION=$[dependencies.HashBaseDependencies.outputs['SetDockerBaseTag.DOCKER_BASE_TAG']]"
 
 - stage: stage_docker_nginx_image_build


### PR DESCRIPTION
The condition in azure didn't seem to take effect so we now check whether to skip the expensive image building in bash. I've tried various combinations of using strings and booleans in the main azure script and docker build template and cannot make Azure Pipelines do what I expect.

I updated the base digest too