### PR TITLE
Update azure and kubernetes deployment notes 

### DIFF
--- a/.azurePipeline/templatePublishLogsFromPods.yml
+++ b/.azurePipeline/templatePublishLogsFromPods.yml
@@ -21,6 +21,7 @@ steps:
   displayName: 'Anonlink Entity Service Backend Worker Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'
@@ -30,6 +31,7 @@ steps:
   displayName: 'Anonlink Entity Service NGINX Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'
@@ -39,6 +41,7 @@ steps:
   displayName: 'Anonlink Entity Service API Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'
@@ -48,6 +51,7 @@ steps:
   displayName: 'DB Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'
@@ -57,6 +61,7 @@ steps:
   displayName: 'Redis Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'
@@ -66,6 +71,7 @@ steps:
   displayName: 'Minio Logs'
   condition: always()
   inputs:
+    failOnStderr: false
     connectionType: 'Kubernetes Service Connection'
     kubernetesServiceEndpoint: ${{ parameters.kubernetesServiceEndpoint }}
     command: 'logs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -236,6 +236,7 @@ stages:
           sed 's|\$PVC'"|$(PVC)|g" | \
           sed 's|\$DEPLOYMENT_NAME'"|$(DEPLOYMENT)|g" > $(Build.ArtifactStagingDirectory)/k8s_test_pvc.yaml
         displayName: 'Create test result volume claim from template'
+
       - task: KubernetesManifest@0
         displayName: 'Create test result volume claim'
         inputs:
@@ -247,20 +248,42 @@ stages:
       # Install Helm on an agent machine
       - task: HelmInstaller@1
         inputs:
-          helmVersionToInstall: '3.1.2'
+          helmVersionToInstall: '2.16.3'
 
-#      - task: HelmDeploy@0
-#        displayName: Helm package
-#        inputs:
-#          command: package
-#          save: false
-#          chartPath: 'deployment/entity-service'
-#          destination: $(Build.ArtifactStagingDirectory)
-#          updatedependency: true
+      - task: HelmDeploy@0
+        displayName: Helm init
+        inputs:
+          connectionType: 'Kubernetes Service Connection'
+          kubernetesServiceConnection: $(CLUSTER)
+          command: init
+          arguments: --client-only
 
-      - script: |
-          helm template --namespace $(NAMESPACE) $(DEPLOYMENT) deployment/entity-service --dependency-update --set global.postgresql.postgresqlPassword=notaproductionpassword,api.ingress.enabled=false,workers.replicaCount=4,api.www.image.repository=$(frontendImageName),api.app.image.repository=$(backendImageName),api.dbinit.image.repository=$(backendImageName),workers.image.repository=$(backendImageName) > $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml
+      - task: HelmDeploy@0
+        displayName: Helm package
+        inputs:
+          command: package
+          save: false
+          chartPath: 'deployment/entity-service'
+          destination: $(Build.ArtifactStagingDirectory)
+          updatedependency: true
+
+      - task: KubernetesManifest@0
+        name: bake
         displayName: Bake K8s manifests from Helm chart
+        inputs:
+          action: 'bake'
+          helmChart: 'deployment/entity-service'
+          namespace: $(NAMESPACE)
+          releaseName: $(DEPLOYMENT)
+          overrides: |
+            api.app.debug:true
+            global.postgresql.postgresqlPassword:notaproductionpassword
+            api.ingress.enabled:false
+            workers.replicaCount:4
+            api.www.image.repository:$(frontendImageName)
+            api.app.image.repository:$(backendImageName)
+            api.dbinit.image.repository:$(backendImageName)
+            workers.image.repository:$(backendImageName)
 
       - task: KubernetesManifest@0
         displayName: Deploy K8s manifest
@@ -268,7 +291,7 @@ stages:
           action: 'deploy'
           failOnStderr: false
           kubernetesServiceConnection: '$(CLUSTER)'
-          manifests: '$(Build.ArtifactStagingDirectory)/manifestsBundle.yaml'
+          manifests: '$(bake.manifestsBundle)'
           namespace: $(NAMESPACE)
           containers: |
             data61/anonlink-nginx:$(DOCKER_TAG)
@@ -358,7 +381,7 @@ stages:
         inputs:
           action: 'delete'
           kubernetesServiceConnection: $(CLUSTER)
-          arguments: '-f $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml'
+          arguments: '-f $(bake.manifestsBundle)'
           namespace: $(NAMESPACE)
 
       # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
@@ -367,5 +390,5 @@ stages:
         inputs:
           action: 'delete'
           kubernetesServiceConnection: $(CLUSTER)
-          arguments: 'pods,jobs,pvc,pv -l deployment=$(DEPLOYMENT)'
+          arguments: 'pods,jobs,pvc,pv,statefulsets,deployment -l deployment=$(DEPLOYMENT)'
           namespace: $(NAMESPACE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,17 +249,17 @@ stages:
         inputs:
           helmVersionToInstall: '3.1.2'
 
-      - task: HelmDeploy@0
-        displayName: Helm package
-        inputs:
-          command: package
-          save: false
-          chartPath: 'deployment/entity-service'
-          destination: $(Build.ArtifactStagingDirectory)
-          updatedependency: true
+#      - task: HelmDeploy@0
+#        displayName: Helm package
+#        inputs:
+#          command: package
+#          save: false
+#          chartPath: 'deployment/entity-service'
+#          destination: $(Build.ArtifactStagingDirectory)
+#          updatedependency: true
 
       - script: |
-          helm template --namespace $(NAMESPACE) $(DEPLOYMENT) deployment/entity-service --set global.postgresql.postgresqlPassword=notaproductionpassword,api.ingress.enabled=false,workers.replicaCount=4,api.www.image.repository=$(frontendImageName),api.app.image.repository=$(backendImageName),api.dbinit.image.repository=$(backendImageName),workers.image.repository=$(backendImageName) > $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml
+          helm template --namespace $(NAMESPACE) $(DEPLOYMENT) deployment/entity-service --dependency-update --set global.postgresql.postgresqlPassword=notaproductionpassword,api.ingress.enabled=false,workers.replicaCount=4,api.www.image.repository=$(frontendImageName),api.app.image.repository=$(backendImageName),api.dbinit.image.repository=$(backendImageName),workers.image.repository=$(backendImageName) > $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml
         displayName: Bake K8s manifests from Helm chart
 
       - task: KubernetesManifest@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,30 +258,17 @@ stages:
           destination: $(Build.ArtifactStagingDirectory)
           updatedependency: true
 
-      - task: KubernetesManifest@0
-        name: bake
+      - script: |
+          helm template --namespace $(NAMESPACE) $(DEPLOYMENT) deployment/entity-service --set global.postgresql.postgresqlPassword=notaproductionpassword,api.ingress.enabled=false,workers.replicaCount=4,api.www.image.repository=$(frontendImageName),api.app.image.repository=$(backendImageName),api.dbinit.image.repository=$(backendImageName),workers.image.repository=$(backendImageName) > $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml
         displayName: Bake K8s manifests from Helm chart
-        inputs:
-          action: 'bake'
-          helmChart: 'deployment/entity-service'
-          namespace: $(NAMESPACE)
-          releaseName: $(DEPLOYMENT)
-          overrides: |
-            api.app.debug:true
-            global.postgresql.postgresqlPassword:notaproductionpassword
-            api.ingress.enabled:false
-            workers.replicaCount:4
-            api.www.image.repository:$(frontendImageName)
-            api.app.image.repository:$(backendImageName)
-            api.dbinit.image.repository:$(backendImageName)
-            workers.image.repository:$(backendImageName)
 
       - task: KubernetesManifest@0
         displayName: Deploy K8s manifest
         inputs:
           action: 'deploy'
+          failOnStderr: false
           kubernetesServiceConnection: '$(CLUSTER)'
-          manifests: '$(bake.manifestsBundle)'
+          manifests: '$(Build.ArtifactStagingDirectory)/manifestsBundle.yaml'
           namespace: $(NAMESPACE)
           containers: |
             data61/anonlink-nginx:$(DOCKER_TAG)
@@ -371,7 +358,7 @@ stages:
         inputs:
           action: 'delete'
           kubernetesServiceConnection: $(CLUSTER)
-          arguments: '-f $(bake.manifestsBundle)'
+          arguments: '-f $(Build.ArtifactStagingDirectory)/manifestsBundle.yaml'
           namespace: $(NAMESPACE)
 
       # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,7 +300,7 @@ stages:
           connectionType: 'Kubernetes Service Connection'
           kubernetesServiceEndpoint: $(CLUSTER)
           command: 'wait'
-          arguments: '--namespace $(NAMESPACE) -ldeployment=$(DEPLOYMENT) --timeout=30s --for=condition=Ready pods'
+          arguments: '--namespace $(NAMESPACE) -ldeployment=$(DEPLOYMENT) --timeout=60s --for=condition=Ready pods'
 
       - task: Kubernetes@1
         displayName: 'Integration test logs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -250,17 +250,10 @@ stages:
           helmVersionToInstall: '3.1.2'
 
       - task: HelmDeploy@0
-        displayName: Helm init
-        inputs:
-          connectionType: 'Kubernetes Service Connection'
-          kubernetesServiceConnection: $(CLUSTER)
-          command: init
-          arguments: --client-only
-
-      - task: HelmDeploy@0
         displayName: Helm package
         inputs:
           command: package
+          save: false
           chartPath: 'deployment/entity-service'
           destination: $(Build.ArtifactStagingDirectory)
           updatedependency: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,6 +244,11 @@ stages:
           manifests: '$(Build.ArtifactStagingDirectory)/k8s_test_pvc.yaml'
           namespace: $(NAMESPACE)
 
+      # Install Helm on an agent machine
+      - task: HelmInstaller@1
+        inputs:
+          helmVersionToInstall: '3.1.2'
+
       - task: HelmDeploy@0
         displayName: Helm init
         inputs:

--- a/deployment/entity-service/requirements.yaml
+++ b/deployment/entity-service/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: redis-ha
-    version: 4.3.3
+    version: 4.4.1
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.redis
   - name: minio

--- a/deployment/entity-service/templates/NOTES.txt
+++ b/deployment/entity-service/templates/NOTES.txt
@@ -24,19 +24,14 @@ Soon you should be able to visit the entity service api.
 {{- else if contains "ClusterIP"  .Values.api.service.type }}
 
 If you're using an ingress controller (the default) you may have to manually
-add the DNS entry for {{ .Values.api.ingress.hosts }} now.
+add the DNS entry for http://{{ .Values.api.ingress.hosts }} now.
 
-Alternatively you can forward the port of the entity service's nginx server to your
+Alternatively you can port forward the entity service API to your
 local machine:
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "es.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME 8080:80
+  export SVC_NAME=$(kubectl get services --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},tier=frontend" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward SVC_NAME 8080:80
 
 And visit http://127.0.0.1:8080/
 
 {{- end }}
-
-2. Task Monitoring
-
-To monitor the entity service tasks (time taken, completions, failures etc)
-You will need to forward a port from the monitoring pod.

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -315,6 +315,17 @@ redis-ha:
     size: 10Gi
   nameOverride: "memstore"
 
+  sysctlImage:
+    enabled: true
+    mountHostSys: true
+    command:
+      - /bin/sh
+      - -xc
+      - |-
+        sysctl -w net.core.somaxconn=10000
+        echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+  exporter:
+    enabled: true
 
 minio:
   ## Configure the object storage

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -258,7 +258,7 @@ postgresql:
     #  memory: 8Gi
     requests:
       #memory: 1Gi
-      cpu: 100m
+      cpu: 200m
 
 
 global:

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -315,6 +315,8 @@ redis-ha:
     size: 10Gi
   nameOverride: "memstore"
 
+  # Enable transparent hugepages
+  # https://github.com/helm/charts/tree/master/stable/redis-ha#host-kernel-settings
   sysctlImage:
     enabled: true
     mountHostSys: true


### PR DESCRIPTION
A new version of helm has been released. We were not pinning the version and many Azure devops commands/tasks required the old version.

Updates the note printed out in helm after a deploy.