### PR TITLE
Feature blocky benchmark

### DIFF
--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -286,9 +286,9 @@ def download_data(config):
     Download data used in the configured experiments.
     On S3, the data is organised in folders for the number of parties (e.g. folder `3Parties` for the data related to
     the 3 party linkage), and then a number a file following the format `PII_{user}_{size_data}.csv`,
-    `clk_{user}_{size_data}_v2.bin`, `clk_{user}_{size_data}.json` and `clknblocks_{user}_{size_data}.json` where $user
-    is a letter starting from `a` indexing the data owner, and `size_data` is a integer representing the number of data
-    rows in the dataset (e.g. 10000). Note that the csv usually has a header.
+    `clk_{user}_{size_data}_v2.bin`, `clk_{user}_{size_data}.json` and `clknblocks_{user}_{size_data}.json` where `user`
+    is a letter starting from `a` indexing the data providers, and `size_data` is an integer representing the number of
+    data rows in the dataset (e.g. 10000). Note that the csv usually has a header.
 
     The data is stored in the folder provided from the configuration, following the same structure as the one on S3.
     """

--- a/benchmarking/default-experiments-wawo-blocking.json
+++ b/benchmarking/default-experiments-wawo-blocking.json
@@ -1,0 +1,29 @@
+[
+  {
+    "sizes": ["100K", "100K"],
+    "threshold": 0.95
+  },
+  {
+    "sizes": ["100K", "100K"],
+    "threshold": 0.80
+  },
+  {
+    "sizes": ["10K", "10K"],
+    "threshold": 0.95
+  },
+  {
+    "sizes": ["100K", "100K"],
+    "use_blocking": true,
+    "threshold": 0.95
+  },
+  {
+    "sizes": ["100K", "100K"],
+    "use_blocking": true,
+    "threshold": 0.80
+  },
+  {
+    "sizes": ["10K", "10K"],
+    "use_blocking": true,
+    "threshold": 0.95
+  }
+]

--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -1,4 +1,4 @@
-anonlink-client==0.0.1
+anonlink-client==0.1.2
 arrow
 boto3
 jsonschema

--- a/docs/benchmarking.rst
+++ b/docs/benchmarking.rst
@@ -63,8 +63,30 @@ To run the benchmarks using the cache volume::
 
 Experiments
 -----------
+The benchmarking script will run a range of experiments, defined in a json file.
 
-Experiments to run can be configured as a simple json document. The default is::
+Data
+~~~~
+
+The experiments use synthetic data generated with the febrl tool. The data is stored in the S3 bucket
+s3://public-linkage-data. The naming convention is {type_of_data}_{party}_{size}.
+
+You'll find
+
+- the PII data for various dataset sizes, the CLKs in binary and json format, generated with the linkage schema defined in ``schema.json``.
+- the corresponding linkage schema in ``schema.json``
+- the blocks, generated with P-Sig blocking.
+- the corresponding blocking schema ``psig_schema.json``
+- the combined ``clknblocks`` files for the different parties and dataset sizes.
+
+This particular blocking schema creates blocks with a median size of 1. The average size does not exceed 10 for any
+dataset, and each entity is part of 5 different blocks.
+
+Config
+~~~~~~
+
+The experiments are configured in a json document. Currently, you can specify the dataset sizes, the linkage threshold,
+the number of repetitions and if blocking should be used. The default is::
 
     [
       {


### PR DESCRIPTION
This extends the benchmark script to be able to run experiments which use blocking.

An experiment definition for blocking looks like this:
```
{
    "sizes": ["100K", "100K"],
    "use_blocking": true,
    "threshold": 0.80
  }
```

The corresponding 'clknblocks' files are uploaded to S3.
For now I haven't changed the `default-experiements.json` file, as the blocked experiments take a very long time and will most likely trigger a timeout. 
Once we addressed that issue in the entity service, we can replace `default-experiements.json` with `default-experiements-wawo-blocking.json`.