### PR TITLE
Fix calculation of total number of comparisons

### DIFF
--- a/backend/entityservice/cache/helpers.py
+++ b/backend/entityservice/cache/helpers.py
@@ -1,3 +1,16 @@
 def _get_run_hash_key(run_id):
     key = f'run:{run_id}'
     return key
+
+
+def _get_project_hash_key(project_id):
+    key = f'project:{project_id}'
+    return key
+
+
+def _convert_redis_result_to_int(res):
+    # redis returns bytes, and None if not present
+    if res is not None:
+        return int(res)
+    else:
+        return None

--- a/backend/entityservice/cache/progress.py
+++ b/backend/entityservice/cache/progress.py
@@ -2,10 +2,28 @@ import structlog
 
 from entityservice.settings import Config as globalconfig
 from entityservice.cache.connection import connect_to_redis
-from entityservice.cache.helpers import _get_run_hash_key
+from entityservice.cache.helpers import _get_run_hash_key, _get_project_hash_key, _convert_redis_result_to_int
+import entityservice.database as db
 
 logger = structlog.get_logger()
 
+
+def get_total_number_of_comparisons(project_id):
+    r = connect_to_redis(read_only=True)
+    key = _get_project_hash_key(project_id)
+    res = r.hget(key, 'total_comparisons')
+    # hget returns None if missing key/name, and bytes if present
+    if res:
+        return _convert_redis_result_to_int(res)
+    else:
+        # Calculate the number of comparisons
+        with db.DBConn() as conn:
+            total_comparisons = db.get_total_comparisons_for_project(conn, project_id)
+        # get a writable connection to redis
+        r = connect_to_redis()
+        res = r.hset(key, 'total_comparisons', total_comparisons)
+        r.expire(key, 60*60)
+        return total_comparisons
 
 def save_current_progress(comparisons, run_id, config=None):
     if config is None:
@@ -22,11 +40,7 @@ def get_progress(run_id):
     r = connect_to_redis(read_only=True)
     key = _get_run_hash_key(run_id)
     res = r.hget(key, 'progress')
-    # redis returns bytes, and None if not present
-    if res is not None:
-        return int(res)
-    else:
-        return None
+    return _convert_redis_result_to_int(res)
 
 
 def clear_progress(run_id):

--- a/backend/entityservice/cache/progress.py
+++ b/backend/entityservice/cache/progress.py
@@ -11,10 +11,11 @@ def save_current_progress(comparisons, run_id, config=None):
     if config is None:
         config = globalconfig
     logger.debug(f"Updating progress. Compared {comparisons} CLKS", run_id=run_id)
-    r = connect_to_redis()
-    key = _get_run_hash_key(run_id)
-    r.hincrby(key, 'progress', comparisons)
-    r.expire(key, config.CACHE_EXPIRY)
+    if comparisons > 0:
+        r = connect_to_redis()
+        key = _get_run_hash_key(run_id)
+        r.hincrby(key, 'progress', comparisons)
+        r.expire(key, config.CACHE_EXPIRY)
 
 
 def get_progress(run_id):

--- a/backend/entityservice/database/selections.py
+++ b/backend/entityservice/database/selections.py
@@ -237,6 +237,7 @@ def get_total_comparisons_for_project(db, project_id):
     :return total number of comparisons for this project
     """
     sql_query = """
+        -- Note this returns a numeric (which psycopg maps to decimal.Decimal) 
         select sum(product) from (select product(count)
         from blocks
         where dp in (
@@ -244,7 +245,7 @@ def get_total_comparisons_for_project(db, project_id):
         )
         GROUP BY block_name) as per_block_product
         """
-    total_comparisons = query_db(db, sql_query, [project_id], one=True)['sum']
+    total_comparisons = int(query_db(db, sql_query, [project_id], one=True)['sum'])
     return total_comparisons
 
 

--- a/backend/entityservice/init-db-schema.sql
+++ b/backend/entityservice/init-db-schema.sql
@@ -248,16 +248,3 @@ CREATE TABLE metrics (
   -- Comparisons per second
   rate BIGINT
 );
-
--- Create a "product" aggregation function
-CREATE OR REPLACE FUNCTION product_sfunc(state numeric, factor numeric)
-RETURNS numeric AS $$
-    SELECT $1 * $2
-$$ LANGUAGE sql;
-
-CREATE AGGREGATE product (
-    sfunc = product_sfunc,
-    basetype = numeric,
-    stype = numeric,
-    initcond = '1'
-);

--- a/backend/entityservice/init-db-schema.sql
+++ b/backend/entityservice/init-db-schema.sql
@@ -248,3 +248,16 @@ CREATE TABLE metrics (
   -- Comparisons per second
   rate BIGINT
 );
+
+-- Create a "product" aggregation function
+CREATE OR REPLACE FUNCTION product_sfunc(state numeric, factor numeric)
+RETURNS numeric AS $$
+    SELECT $1 * $2
+$$ LANGUAGE sql;
+
+CREATE AGGREGATE product (
+    sfunc = product_sfunc,
+    basetype = numeric,
+    stype = numeric,
+    initcond = '1'
+);

--- a/backend/entityservice/tasks/run.py
+++ b/backend/entityservice/tasks/run.py
@@ -45,7 +45,6 @@ def prerun_check(project_id, run_id, parent_span=None):
 
         log.debug("Updating redis cache for run")
         set_run_state_active(run_id)
-        progress_cache.save_current_progress(comparisons=0, run_id=run_id)
 
     create_comparison_jobs.apply_async(
         kwargs={'project_id': project_id, 'run_id': run_id, 'parent_span': prerun_check.get_serialized_span()},

--- a/backend/entityservice/views/run/status.py
+++ b/backend/entityservice/views/run/status.py
@@ -51,10 +51,8 @@ def get(project_id, run_id):
         # Computing similarity
         abs_val = progress_cache.get_progress(run_id)
         if abs_val is not None:
-            with db.DBConn() as conn:
-                # todo cache this
-                max_val = db.get_total_comparisons_for_project(conn, project_id)
-                logger.debug(f"total comparisons: {max_val}")
+            max_val = progress_cache.get_total_number_of_comparisons(project_id)
+            logger.debug(f"total comparisons: {max_val}")
     else:
         # Solving for mapping (no progress)
         abs_val = None

--- a/backend/entityservice/views/run/status.py
+++ b/backend/entityservice/views/run/status.py
@@ -52,7 +52,9 @@ def get(project_id, run_id):
         abs_val = progress_cache.get_progress(run_id)
         if abs_val is not None:
             with db.DBConn() as conn:
+                # todo cache this
                 max_val = db.get_total_comparisons_for_project(conn, project_id)
+                logger.debug(f"total comparisons: {max_val}")
     else:
         # Solving for mapping (no progress)
         abs_val = None


### PR DESCRIPTION
This calculation now takes into account the use of blocking. Also because it seemed somewhat non-trivial to compute I added caching in redis.

Closes #542