### PR TITLE
Use docker-compose without having to set the --project-directory

### DIFF
--- a/.azurePipeline/runDockerComposeTests.sh
+++ b/.azurePipeline/runDockerComposeTests.sh
@@ -56,10 +56,13 @@ process_args "$@"
 [[ $TYPE != "integrationtests" && $TYPE != "benchmark" && $TYPE != "tutorials" ]] && echoerr "ERROR: Unrecognized type '$TYPE'. Should be equal to 'integrationtests', 'benchmark' or 'tutorials'" && exit 1
 export TAG=$TAG
 
-commandPrefix="docker-compose -f tools/docker-compose.yml -f tools/ci.yml --project-directory . "
+commandPrefix="docker-compose -f docker-compose.yml -f ci.yml "
 if [[ "$NO_ANSI" == "TRUE" ]]; then
   commandPrefix="$commandPrefix --no-ansi "
 fi
+
+# change current working directory to the tools directory
+cd "${0%/*}/../tools"
 
 echo "Initialise the database and the object store"
 $commandPrefix -p $PROJECT_NAME up objectstore_init db_init
@@ -80,7 +83,7 @@ fi
 $commandPrefix -p $PROJECT_NAME up --abort-on-container-exit --exit-code-from $TYPE db minio redis backend worker nginx $TYPE
 exit_code=$?
 echo "Retrieve the $TYPE tests results." 
-$commandPrefix -p $PROJECT_NAME ps -q $TYPE | xargs -I@ docker cp @:$CREATED_RESULT_FILE $RESULT_FILE
+$commandPrefix -p $PROJECT_NAME ps -q $TYPE | xargs -I@ docker cp @:$CREATED_RESULT_FILE ../$RESULT_FILE
 
 echo "Cleaning."
 $commandPrefix -p $PROJECT_NAME down -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ stages:
     - template: .azurePipeline/templateSetVariableDockerTag.yml
     - script: |
         ./.azurePipeline/runDockerComposeTests.sh --no-ansi -p es$(DOCKER_TAG)$(Build.SourceVersion) -t $(DOCKER_TAG) -o $(resultFile) --type integrationtests
-      displayName: 'Start docker compose benchmark'
+      displayName: 'Start docker compose'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     entrypoint: |
       /bin/sh /opt/init-object-store.sh
     volumes:
-      - ./tools/init-object-store.sh:/opt/init-object-store.sh:ro
+      - ./init-object-store.sh:/opt/init-object-store.sh:ro
     depends_on:
       - minio
 


### PR DESCRIPTION
Just a small tidy up, there was some inconsistency between how we used docker-compose and how the average user might expect to.