### PR TITLE
disable password prompt for adduser

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -406,19 +406,19 @@ stages:
           JobAttempt: $(System.JobAttempt)
 
       # Cleanup
-    #  - task: KubernetesManifest@0
-    #    condition: always()
-    #    inputs:
-    #      action: 'delete'
-    #      kubernetesServiceConnection: $(CLUSTER)
-    #      arguments: '-f $(bake.manifestsBundle)'
-    #      namespace: $(NAMESPACE)
+      - task: KubernetesManifest@0
+        condition: always()
+        inputs:
+          action: 'delete'
+          kubernetesServiceConnection: $(CLUSTER)
+          arguments: '-f $(bake.manifestsBundle)'
+          namespace: $(NAMESPACE)
 
       # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
-    #  - task: KubernetesManifest@0
-    #    condition: always()
-    #    inputs:
-    #      action: 'delete'
-    #      kubernetesServiceConnection: $(CLUSTER)
-    #      arguments: 'pods,jobs,pvc,pv,statefulsets,deployment -l deployment=$(DEPLOYMENT)'
-    #      namespace: $(NAMESPACE)
+      - task: KubernetesManifest@0
+        condition: always()
+        inputs:
+          action: 'delete'
+          kubernetesServiceConnection: $(CLUSTER)
+          arguments: 'pods,jobs,pvc,pv,statefulsets,deployment -l deployment=$(DEPLOYMENT)'
+          namespace: $(NAMESPACE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -406,19 +406,19 @@ stages:
           JobAttempt: $(System.JobAttempt)
 
       # Cleanup
-      - task: KubernetesManifest@0
-        condition: always()
-        inputs:
-          action: 'delete'
-          kubernetesServiceConnection: $(CLUSTER)
-          arguments: '-f $(bake.manifestsBundle)'
-          namespace: $(NAMESPACE)
+    #  - task: KubernetesManifest@0
+    #    condition: always()
+    #    inputs:
+    #      action: 'delete'
+    #      kubernetesServiceConnection: $(CLUSTER)
+    #      arguments: '-f $(bake.manifestsBundle)'
+    #      namespace: $(NAMESPACE)
 
       # Note that all the test resources (i.e. the pvc, the job and the pod have a label `deployment` set to $(DEPLOYMENT)
-      - task: KubernetesManifest@0
-        condition: always()
-        inputs:
-          action: 'delete'
-          kubernetesServiceConnection: $(CLUSTER)
-          arguments: 'pods,jobs,pvc,pv,statefulsets,deployment -l deployment=$(DEPLOYMENT)'
-          namespace: $(NAMESPACE)
+    #  - task: KubernetesManifest@0
+    #    condition: always()
+    #    inputs:
+    #      action: 'delete'
+    #      kubernetesServiceConnection: $(CLUSTER)
+    #      arguments: 'pods,jobs,pvc,pv,statefulsets,deployment -l deployment=$(DEPLOYMENT)'
+    #      namespace: $(NAMESPACE)

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -16,7 +16,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 RUN python -c "import clkhash; print('clkhash version:', clkhash.__version__)"
 
 RUN mkdir /cache
-RUN adduser user && \
+RUN adduser --disabled-password --gecos '' user && \
     chown user:user /app /var/log /cache
 VOLUME /cache
 USER user

--- a/e2etests/tests/test_project_run_results.py
+++ b/e2etests/tests/test_project_run_results.py
@@ -3,7 +3,7 @@ from e2etests.util import create_project_no_data, post_run, get_run_result
 
 def test_run_similarity_score_results(requests, similarity_scores_project, threshold):
     run_id = post_run(requests, similarity_scores_project, threshold)
-    result = get_run_result(requests, similarity_scores_project, run_id, timeout=120)
+    result = get_run_result(requests, similarity_scores_project, run_id, timeout=240)
     assert 'similarity_scores' in result
     for (party_id_1, rec_id_1), (party_id_2, rec_id_2), score in result['similarity_scores']:
         assert 0.0 <= score >= 1.0
@@ -16,7 +16,7 @@ def test_run_similarity_score_results(requests, similarity_scores_project, thres
 
 def test_run_permutations_results(requests, permutations_project, threshold):
     run_id = post_run(requests, permutations_project, threshold)
-    mask_result = get_run_result(requests, permutations_project, run_id, timeout=120)
+    mask_result = get_run_result(requests, permutations_project, run_id, timeout=240)
     assert 'mask' in mask_result
     assert len(mask_result['mask']) == min(permutations_project['size'])
 
@@ -37,7 +37,7 @@ def test_run_permutations_results(requests, permutations_project, threshold):
 
 def test_run_groups_results(requests, groups_project, threshold):
     run_id = post_run(requests, groups_project, threshold)
-    result = get_run_result(requests, groups_project, run_id, timeout=120)
+    result = get_run_result(requests, groups_project, run_id, timeout=240)
     
     assert 'groups' in result
     groups = result['groups']

--- a/e2etests/tests/test_project_uploads.py
+++ b/e2etests/tests/test_project_uploads.py
@@ -262,7 +262,7 @@ def test_project_binary_data_uploaded(requests, valid_project_params, binary_tes
             binary_test_file_path, new_project_data['project_id'], token, 1000)
 
     run_id = post_run(requests, new_project_data, 0.99)
-    result = get_run_result(requests, new_project_data, run_id, wait=True)
+    result = get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
 
     if valid_project_params['result_type'] == 'groups':
         assert 'groups' in result
@@ -307,7 +307,7 @@ def test_project_binary_data_upload_with_different_encoded_size(
             requests, d, project_id, token, 500, size=encoding_size)
 
     run_id = post_run(requests, new_project_data, 0.99)
-    result = get_run_result(requests, new_project_data, run_id, wait=True)
+    result = get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
     if valid_project_params['result_type'] == 'groups':
         assert 'groups' in result
         groups = result['groups']
@@ -330,7 +330,7 @@ def test_project_json_data_upload_with_various_encoded_sizes(
     )
 
     run_id = post_run(requests, new_project_data, 0.9)
-    result = get_run_result(requests, new_project_data, run_id, wait=True)
+    result = get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
     if result_type == 'groups':
         assert 'groups' in result
         # This is a pretty bad bound, but we're not testing the
@@ -350,7 +350,7 @@ def test_project_json_data_upload_with_mismatched_encoded_size(
 
     with pytest.raises(AssertionError):
         run_id = post_run(requests, new_project_data, 0.9)
-        get_run_result(requests, new_project_data, run_id, wait=True)
+        get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
 
 
 def test_project_json_data_upload_with_invalid_encoded_size(
@@ -366,7 +366,7 @@ def test_project_json_data_upload_with_invalid_encoded_size(
 
     with pytest.raises(AssertionError):
         run_id = post_run(requests, new_project_data, 0.9)
-        get_run_result(requests, new_project_data, run_id, wait=True)
+        get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
 
 
 def test_project_json_data_upload_with_too_small_encoded_size(
@@ -382,7 +382,7 @@ def test_project_json_data_upload_with_too_small_encoded_size(
 
     with pytest.raises(AssertionError):
         run_id = post_run(requests, new_project_data, 0.9)
-        get_run_result(requests, new_project_data, run_id, wait=True)
+        get_run_result(requests, new_project_data, run_id, wait=True, timeout=240)
 
 
 def test_project_json_data_upload_with_too_large_encoded_size(

--- a/e2etests/tests/test_results_correctness.py
+++ b/e2etests/tests/test_results_correctness.py
@@ -45,7 +45,7 @@ def test_similarity_scores(requests, the_truth):
         (the_truth['clks_a'], the_truth['clks_b']),
         result_type='similarity_scores')
     run = post_run(requests, project_data, threshold=the_truth['threshold'])
-    result = get_run_result(requests, project_data, run, timeout=60)
+    result = get_run_result(requests, project_data, run, timeout=240)
     
     true_scores = the_truth['similarity_scores']
     result_scores = {tuple(index for _, index in sorted([a, b])): score
@@ -67,7 +67,7 @@ def test_permutation(requests, the_truth):
         (the_truth['clks_a'], the_truth['clks_b']),
         result_type='permutations')
     run = post_run(requests, project_data, threshold=the_truth['threshold'])
-    mask_result = get_run_result(requests, project_data, run, timeout=60)
+    mask_result = get_run_result(requests, project_data, run, timeout=240)
     perm_a_result = get_run_result(requests, project_data, run, result_token=r_a['receipt_token'], wait=False)
     perm_b_result = get_run_result(requests, project_data, run, result_token=r_b['receipt_token'], wait=False)
     # compare permutations and mask against mapping of the truth
@@ -94,7 +94,7 @@ def test_groups(requests, the_truth):
         (the_truth['clks_a'], the_truth['clks_b']),
         result_type='groups')
     run = post_run(requests, project_data, threshold=the_truth['threshold'])
-    result = get_run_result(requests, project_data, run)
+    result = get_run_result(requests, project_data, run, timeout=240)
     # compare mapping with the truth
     result_groups = result['groups']
     true_groups = the_truth['groups']

--- a/e2etests/tests/test_results_correctness_multiparty.py
+++ b/e2etests/tests/test_results_correctness_multiparty.py
@@ -35,7 +35,7 @@ def test_groups_correctness(requests):
         binary=True, hash_size=DATA_HASH_SIZE)
     try:
         run = post_run(requests, project_data, threshold=THRESHOLD)
-        result_groups = get_run_result(requests, project_data, run)['groups']
+        result_groups = get_run_result(requests, project_data, run, timeout=240)['groups']
     finally:
         delete_project(requests, project_data)
     


### PR DESCRIPTION
I found these error messages in the Azure logs when building the benchmark container:
```
Step 10/14 : RUN adduser user &&     chown user:user /app /var/log /cache
 ---> Running in e69fcbfba95d
Adding user `user' ...
Adding new group `user' (1000) ...
Adding new user `user' (1000) with group `user' ...
Creating home directory `/home/user' ...
Copying files from `/etc/skel' ...
New password: Password change aborted.
passwd: Authentication token manipulation error
passwd: password unchanged
Use of uninitialized value $answer in chop at /usr/sbin/adduser line 556.
Use of uninitialized value $answer in pattern match (m//) at /usr/sbin/adduser line 557.
Try again? [y/N] Changing the user information for user
Enter the new value, or press ENTER for the default
	Full Name []: 	Room Number []: 	Work Phone []: 	Home Phone []: 	Other []: Use of uninitialized value $answer in chop at /usr/sbin/adduser line 582.
Use of uninitialized value $answer in pattern match (m//) at /usr/sbin/adduser line 583.
Is the information correct? [Y/n] Removing intermediate container e69fcbfba95d
```
with the proposed fix, this disappears:
```
Step 10/14 : RUN adduser --disabled-password --gecos '' user &&     chown user:user /app /var/log /cache
 ---> Running in 5ad74773a66c
Adding user `user' ...
Adding new group `user' (1000) ...
Adding new user `user' (1000) with group `user' ...
Creating home directory `/home/user' ...
Copying files from `/etc/skel' ...
Removing intermediate container 5ad74773a66c
```