### PR TITLE
catching NoSuchBucket exception at cleanup

### DIFF
--- a/backend/entityservice/tasks/project_cleanup.py
+++ b/backend/entityservice/tasks/project_cleanup.py
@@ -48,4 +48,7 @@ def delete_minio_objects(filenames, project_id, parent_span=None):
 
     if Config.UPLOAD_OBJECT_STORE_ENABLED:
         log.debug("Deleting everything uploaded to object store for project")
-        delete_object_store_folder(mc, Config.UPLOAD_OBJECT_STORE_BUCKET, f"{project_id}/")
+        try:
+            delete_object_store_folder(mc, Config.UPLOAD_OBJECT_STORE_BUCKET, f"{project_id}/")
+        except MinioError as e:
+            log.warning(f"Error occurred while trying to remove files from object store upload bucket: {e}")


### PR DESCRIPTION
we had this problem in the CI that sometimes the tests would fail with a `NoSuchBucket` exception.
It turns out that this happens during project cleanup. I wrapped the offending line in a try-catch and log a warning message.