### PR TITLE
fix NoSuchBucket error

### DIFF
--- a/backend/entityservice/views/objectstore.py
+++ b/backend/entityservice/views/objectstore.py
@@ -7,7 +7,7 @@ from minio.error import ResponseError
 
 from entityservice.settings import Config as config
 import entityservice.database as db
-from entityservice.object_store import connect_to_upload_object_store
+from entityservice.object_store import connect_to_upload_object_store, connect_to_object_store
 from entityservice.utils import safe_fail_request, object_store_upload_path
 from entityservice.views import bind_log_and_span, precheck_upload_token
 from entityservice.views.serialization import ObjectStoreCredentials
@@ -68,6 +68,7 @@ def authorize_external_upload(project_id):
 
         log.info("Retrieved temporary credentials")
 
+        client = connect_to_object_store()
         try:
             log.info(f'bucket {bucket_name} exists: {client.bucket_exists(bucket_name)}')
         except ResponseError as err:

--- a/backend/entityservice/views/objectstore.py
+++ b/backend/entityservice/views/objectstore.py
@@ -3,6 +3,7 @@ import json
 import opentracing
 from flask import request
 from minio.credentials import AssumeRoleProvider, Credentials
+from minio.error import ResponseError
 
 from entityservice.settings import Config as config
 import entityservice.database as db
@@ -66,6 +67,11 @@ def authorize_external_upload(project_id):
         expiry = credentials_provider._expiry._expiration
 
         log.info("Retrieved temporary credentials")
+
+        try:
+            log.info(f'bucket {bucket_name} exists: {client.bucket_exists(bucket_name)}')
+        except ResponseError as err:
+            log.error(f'bucket {bucket_name} not found!?!?! {err}')
 
     credentials_json = ObjectStoreCredentials().dump(credential_values)
     log.debug("Temp credentials", **credentials_json)

--- a/e2etests/tests/test_project_uploads.py
+++ b/e2etests/tests/test_project_uploads.py
@@ -84,26 +84,7 @@ def test_project_single_party_data_uploaded_encodings_and_blocks_format(requests
 
 def test_project_upload_external_encodings(requests, a_project, binary_test_file_path):
 
-    r = requests.get(
-        url + 'projects/{}/authorize-external-upload'.format(a_project['project_id']),
-        headers={'Authorization': a_project['update_tokens'][0]},
-    )
-    assert r.status_code == 201
-    upload_response = r.json()
-
-    credentials = upload_response['credentials']
-    upload_info = upload_response['upload']
-
-    # Use Minio python client to upload data
-
-    mc = Minio(
-        minio_host or upload_info['endpoint'],
-        access_key=credentials['AccessKeyId'],
-        secret_key=credentials['SecretAccessKey'],
-        session_token=credentials['SessionToken'],
-        region='us-east-1',
-        secure=upload_info['secure']
-    )
+    mc, upload_info = get_temp_upload_client(a_project, requests, a_project['update_tokens'][0])
 
     etag = mc.fput_object(
         upload_info['bucket'],


### PR DESCRIPTION
This test failed intermittently on Azure with 
`minio.error.NoSuchBucket: NoSuchBucket: message: The specified bucket does not exist.`

I cannot reproduce this with a local deployment. Also, I can run the test locally against the deployed service without errors. 

I still don't know why this happens. I propose a fix, that, at upload authorization, checks if the bucket exists and if not creates it.

You can see it working in the [CI logs](https://dev.azure.com/data61/Anonlink/_build/results?buildId=2272&view=logs&j=aac7439e-97d6-512d-3e06-b7446a540cac&t=d5e89444-f1ca-5d4b-026a-e4bc7ee5428c) line 5288.