### PR TITLE
Update minio server

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,15 +270,7 @@ stages:
       # Install Helm on an agent machine
       - task: HelmInstaller@1
         inputs:
-          helmVersionToInstall: '2.16.3'
-
-      - task: HelmDeploy@0
-        displayName: Helm init
-        inputs:
-          connectionType: 'Kubernetes Service Connection'
-          kubernetesServiceConnection: $(CLUSTER)
-          command: init
-          arguments: --client-only
+          helmVersionToInstall: 'latest'
 
       - task: HelmDeploy@0
         displayName: Helm package
@@ -308,8 +300,8 @@ stages:
             api.dbinit.image.repository:$(backendImageName)
             workers.image.repository:$(backendImageName)
             workers.image.pullPolicy:Always
-            anonlink.objectstore.secure:false
             anonlink.objectstore.uploadEnabled:true
+            anonlink.objectstore.uploadSecure:false
             anonlink.objectstore.uploadAccessKey:testUploadAccessKey
             anonlink.objectstore.uploadSecretKey:testUploadSecretKey
             minio.accessKey:testMinioAccessKey

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.12.1
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -21,13 +21,13 @@ RUN apk add --no-cache \
     libstdc++=9.3.0-r2 \
     mpc1-dev=1.1.0-r1 \
     yajl=2.1.0-r1 \
-    libpq=12.3-r2 && \
+    libpq=12.5-r0 && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     apk add --no-cache --virtual .build-deps \
     g++=9.3.0-r2 \
     python3-dev=3.8.5-r0 \
     yajl-dev=2.1.0-r1 \
-    postgresql-dev=12.3-r2 \
+    postgresql-dev=12.5-r0 \
     libffi-dev=3.3-r2 \
     gmp-dev=6.2.0-r0 \
     mpfr-dev=4.0.2-r4 \

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,5 +1,6 @@
 anonlink==0.13.1
 anonlink-client==0.1.4
+bitarray-hardbyte==1.2.2
 bitmath==1.3.1.2
 celery==4.4.7
 clkhash==0.16.0
@@ -17,7 +18,7 @@ minio==5.0.10
 opentracing==2.3.0
 opentracing_instrumentation==3.2.1
 psycopg2==2.8.4
-pytest==5.4.3
+pytest==6.1.2
 pytest-xdist==1.29.0
 PyYAML==5.3
 redis==3.4.1

--- a/deployment/entity-service/requirements.yaml
+++ b/deployment/entity-service/requirements.yaml
@@ -4,8 +4,8 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.redis
   - name: minio
-    version: 5.0.27
-    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 8.0.5
+    repository: https://helm.min.io/
     condition: provision.minio
   - name: postgresql
     version: 8.9.1

--- a/deployment/entity-service/requirements.yaml
+++ b/deployment/entity-service/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: provision.redis
   - name: minio
-    version: 8.0.5
+    version: 8.0.6
     repository: https://helm.min.io/
     condition: provision.minio
   - name: postgresql

--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -31,11 +31,15 @@ data:
 
   UPLOAD_OBJECT_STORE_ENABLED: {{ .Values.anonlink.objectstore.uploadEnabled | quote }}
 
-  {{ if .Values.minio.ingress.enabled }}
-  UPLOAD_OBJECT_STORE_SERVER: {{ index .Values.minio.ingress.hosts 0 }}
+  {{ if .Values.anonlink.objectstore.uploadServer }}
+  UPLOAD_OBJECT_STORE_SERVER: {{ .Values.anonlink.objectstore.uploadServer | quote }}
+  {{ else if .Values.minio.ingress.enabled }}
+  UPLOAD_OBJECT_STORE_SERVER: {{ index .Values.minio.ingress.hosts 0 | quote }}
+  {{ else }}
+  UPLOAD_OBJECT_STORE_SERVER: "{{ .Release.Name }}-{{ .Values.minio.nameOverride }}:{{ .Values.minio.service.port }}"
   {{ end }}
 
-  UPLOAD_OBJECT_STORE_SECURE: {{ .Values.anonlink.objectstore.secure | quote }}
+  UPLOAD_OBJECT_STORE_SECURE: {{ .Values.anonlink.objectstore.uploadSecure | quote }}
 
   UPLOAD_OBJECT_STORE_BUCKET: {{ required "anonlink.objectstore.uploadBucket.name is required." .Values.anonlink.objectstore.uploadBucket.name | quote }}
 

--- a/deployment/entity-service/values.yaml
+++ b/deployment/entity-service/values.yaml
@@ -14,6 +14,13 @@ anonlink:
     ## via the object store. See section `minio.ingress` to create an ingress for minio.
     uploadEnabled: true
 
+    ## Server used as the external object store URL - provided to clients so should be externally
+    ## accessible. If not provided, the minio.ingress is used (if enabled).
+    #uploadServer: "s3.amazonaws.com"
+
+    ## Tell clients to make secure connections to the upload object store.
+    uploadSecure: true
+
     ## Object store credentials used to grant temporary upload access to clients
     ## Will be created with an "upload only" policy for a upload bucket if using the default
     ## MINIO provisioning.
@@ -23,9 +30,6 @@ anonlink:
     ## The bucket for client uploads.
     uploadBucket:
       name: "uploads"
-
-    ## Allow only secure connections to the object store.
-    secure: true
 
 
 api:
@@ -357,10 +361,6 @@ minio:
   ## the object store is exposed to the internet
   #accessKey: "exampleMinioAccessKey"
   #secretKey: "exampleMinioSecretKet"
-
-  ## Settings required for connecting to another object store, the server is ignored
-  ## if provisioning minio during deployment.
-  server: "s3.amazonaws.com"
 
   defaultBucket:
     enabled: true

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2020-04-15T19-42-18Z
+    image: minio/minio:RELEASE.2020-12-03T05-49-24Z
     command: server /export
     environment:
       - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE


### PR DESCRIPTION
Update the Minio server used by docker-compose and the k8s deployment.

For the kubernetes deployment, the [helm repository being used](https://github.com/helm/charts/tree/master/stable/minio#notice-this-chart-has-moved) was actually [deprecated](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice) so I've switched Minio over to use their recommended helm repo - https://helm.min.io/

The biggest change is probably the behaviour of the "external minio server" configured by `UPLOAD_OBJECT_STORE_SERVER`. I had made an assumption that the provisioned Minio would either be exposed via an ingress, or an external object store would be used. There are many cases where the system might be exposed differently so that is now a bit more configurable.

- Updates helm used by azure-pipeline to latest (currently version 3) which no longer requires initialisation.
- I pinned `bitarray-hardbyte==1.2.2` because of a test failure with the newer 1.6 release. 
- Updates a few dependencies in base
- I also tried to update the minio-py client to `6.0.2` to be compatible with anonlink-client... but went down the rabbit hole and found you'd already been there @wilko77  https://github.com/minio/minio-py/issues/957

