### PR TITLE
Run migration jobs after upgrade as well as after install

### DIFF
--- a/deployment/entity-service/Chart.yaml
+++ b/deployment/entity-service/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     repository: https://dandydeveloper.github.io/charts
     condition: provision.redis
   - name: minio
-    version: 8.0.6
+    version: 8.0.10
     repository: https://helm.min.io/
     condition: provision.minio
   - name: postgresql

--- a/deployment/entity-service/templates/init-db-job.yaml
+++ b/deployment/entity-service/templates/init-db-job.yaml
@@ -10,8 +10,8 @@ metadata:
     # This job only gets executed on install, not after an upgrade.
     # Manual intervention (or a job with a post-upgrade hook) is required to migrate a
     # production database.
-    "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   template:
     metadata:

--- a/deployment/entity-service/templates/init-db-job.yaml
+++ b/deployment/entity-service/templates/init-db-job.yaml
@@ -7,9 +7,6 @@ metadata:
     {{- include "es.release_labels" . | indent 4 }}
     tier: aux
   annotations:
-    # This job only gets executed on install, not after an upgrade.
-    # Manual intervention (or a job with a post-upgrade hook) is required to migrate a
-    # production database.
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:

--- a/deployment/entity-service/templates/init-objectstore-job.yaml
+++ b/deployment/entity-service/templates/init-objectstore-job.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "es.release_labels" . | indent 4 }}
     tier: aux
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   template:
     metadata:


### PR DESCRIPTION
Both the database migration and object store init job's handle being run multiple times. This small tweak to the helm hooks ensures those jobs also get run after an upgrade - enabling a kubernetes deployment installed via helm to upgrade even if new minio buckets, policies or users are added, or more commonly if the database schema changes.

Object store init job on running twice:
```
mc version RELEASE.2021-02-14T04-28-06Z
== Initialising Object Store ==
mc: <ERROR> Unable to make bucket `minio/uploads`. Your previous request to create the named bucket succeeded and you already own it.
Added user `EXAMPLE_UPLOAD_ACCESS_KEY` successfully.
Policy writeonly is set on user `EXAMPLE_UPLOAD_ACCESS_KEY`
== Object Store Root Upload User Created ==
Added user `EXAMPLE_DOWNLOAD_ACCESS_KEY` successfully.
Policy readonly is set on user `EXAMPLE_DOWNLOAD_ACCESS_KEY`
== Object Store Root Download User Created ==
== Object Store Initialised ==
```

Database init job on running twice:
```
2021/02/19 23:51:25 Waiting for: tcp://db:5432
2021/02/19 23:51:25 Connected to tcp://db:5432
Context impl PostgresqlImpl.
Will assume transactional DDL.
2021/02/19 23:51:27 Command finished successfully.
```

