### PR TITLE
CI e2e test, validate test file existence

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,6 +382,15 @@ stages:
           command: 'cp'
           arguments: '$(NAMESPACE)/$(POD_NAME):/mnt/results.xml k8s-results.xml'
 
+      - script: |
+          if [ -f "k8s-results.xml" ]; then
+            echo "Result file 'k8s-results.xml' exists"
+          else
+            echo "Result file 'k8s-results.xml' does not exist"
+            exit 1
+          fi
+        displayName: 'Check test result file existence'
+
       # Publish the test results.
       - task: PublishTestResults@2
         condition: succeeded()


### PR DESCRIPTION
Add a step in the integration test pipeline validating if a test result file exists, otherwise fails.
This feature is only added for the integration tests, not being sure if this is required for other steps.

Few notes:
 - a [feature request](https://github.com/microsoft/azure-pipelines-tasks/issues/13275) has been opened in Azure Pipeline `PublishTestResult` task for it to fail if no test file are present (instead of just printing a warning
 - the k8s task which does the `cp` is not failing if the file is not present. I did not find any way to parametrise this from their [documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/kubernetes?view=azure-devops#commands) and it seems to be a common issue with other commands such as [login](https://github.com/microsoft/azure-pipelines-tasks/issues/14283)
 - one comment from https://github.com/microsoft/azure-pipelines-tasks/issues/14283 is simply to add a step, with some bash to validate the file existence or not. Note that I did not find any task doing this directly (the search was short though).

It would be good to validate that this work as intended. To do so, I would recommend:
 - running the pipeline with the line 386 pointing to a non existent file -> checking that the pipeline stops on failure
 - brining back the expected behaviour after validation.