### PR TITLE
Hash provided block identifier before storing in DB

### DIFF
--- a/backend/entityservice/database/insertions.py
+++ b/backend/entityservice/database/insertions.py
@@ -31,7 +31,8 @@ def insert_new_run(db, run_id, project_id, threshold, name, type, notes=''):
         RETURNING run_id;
         """
     with db.cursor() as cur:
-        run_id = execute_returning_id(cur, sql_query, [run_id, project_id, name, notes, threshold, 'created', type])
+        run_id = execute_returning_id(cur, sql_query,
+                                      [run_id, project_id, name, notes, threshold, 'created', type])
     return run_id
 
 

--- a/backend/entityservice/database/selections.py
+++ b/backend/entityservice/database/selections.py
@@ -377,7 +377,7 @@ def get_encodings_of_multiple_blocks(db, dp_id, block_ids):
 
     cur = db.cursor()
     sql_query = """
-    SELECT  encodingblocks.block_id, encodingblocks.entity_id, encodings.encoding 
+    SELECT encodingblocks.block_id, encodingblocks.entity_id, encodings.encoding 
     FROM encodingblocks, encodings
     WHERE
       encodingblocks.dp = {} AND

--- a/backend/entityservice/encoding_storage.py
+++ b/backend/entityservice/encoding_storage.py
@@ -1,3 +1,5 @@
+from hashlib import blake2b
+
 import math
 from collections import defaultdict
 from itertools import zip_longest
@@ -33,12 +35,12 @@ def stream_json_clksnblocks(f):
     }
 
     :param f: JSON file containing clksnblocks data.
-    :return: Generator of (entity_id, base64 encoding, list of blocks)
+    :return: Generator of (entity_id, base64 encoding, iterable of hashed block names)
     """
     # At some point the user may supply the entity id. For now we use the order of uploaded encodings.
     for i, obj in enumerate(ijson.items(f, 'clknblocks.item')):
         b64_encoding, *blocks = obj
-        yield i, deserialize_bytes(b64_encoding), blocks
+        yield i, deserialize_bytes(b64_encoding), map(hash_block_name, blocks)
 
 
 def convert_encodings_from_base64_to_binary(encodings: Iterator[Tuple[str, str, List[str]]]):
@@ -94,8 +96,9 @@ def store_encodings_in_db(conn, dp_id, encodings: Iterator[Tuple[str, bytes, Lis
 
     for group in _grouper(encodings, n=_estimate_group_size(encoding_size)):
         encoding_ids, encodings, blocks = _transpose(group)
-        assert len(blocks) == len(encodings)
-        assert len(encoding_ids) == len(encodings)
+        assert len(blocks) == len(encodings), "Block length and encoding length don't match"
+        assert len(encoding_ids) == len(encodings), "Length of encoding ids and encodings don't match"
+        logger.debug("Processing group", num_encoding_ids=len(encoding_ids), num_blocks=len(blocks))
         insert_encodings_into_blocks(conn, dp_id, block_names=blocks, entity_ids=encoding_ids, encodings=encodings)
 
 
@@ -224,13 +227,16 @@ def include_encoding_id_in_json_stream(stream, size, count):
     """
     binary_formatter = binary_format(size)
 
-
     def encoding_iterator(filter_stream):
         # Assumes encoding id and block info not provided (yet)
         for entity_id, encoding in zip(range(count), filter_stream):
             yield str(entity_id), binary_formatter.pack(entity_id, deserialize_bytes(encoding)), [DEFAULT_BLOCK_ID]
 
-
     return encoding_iterator(stream)
 
 
+def hash_block_name(provided_block_name):
+    block_hmac_instance = blake2b(digest_size=32)
+    block_hmac_instance.update(str(provided_block_name).encode())
+    provided_block_name = block_hmac_instance.hexdigest()
+    return provided_block_name

--- a/backend/entityservice/encoding_storage.py
+++ b/backend/entityservice/encoding_storage.py
@@ -140,6 +140,7 @@ def get_encoding_chunks(conn, package, encoding_size=128):
         i = 0
 
         bit_packing_struct = binary_format(encoding_size)
+
         def block_values_iter(values):
             block_id, entity_id, encoding = next(values)
             entity_ids = [entity_id]

--- a/backend/entityservice/error_checking.py
+++ b/backend/entityservice/error_checking.py
@@ -1,9 +1,12 @@
+from structlog import get_logger
 from textwrap import dedent
 
 from entityservice.database import DBConn, get_project_schema_encoding_size, get_filter_metadata, \
     update_encoding_metadata
 from entityservice.settings import Config as config
 from entityservice.tasks import delete_minio_objects
+
+logger = get_logger()
 
 
 class InvalidEncodingError(ValueError):
@@ -22,6 +25,7 @@ def check_dataproviders_encoding(project_id, encoding_size):
         """))
     with DBConn() as db:
         project_encoding_size = get_project_schema_encoding_size(db, project_id)
+        logger.debug(f"Project encoding size is {project_encoding_size}")
     if project_encoding_size is not None and encoding_size != project_encoding_size:
         raise InvalidEncodingError(dedent(f"""User provided encodings were an invalid size
         Expected {project_encoding_size} but got {encoding_size}.

--- a/backend/entityservice/tasks/comparing.py
+++ b/backend/entityservice/tasks/comparing.py
@@ -277,6 +277,7 @@ def compute_filter_similarity(package, project_id, run_id, threshold, encoding_s
     task_span = compute_filter_similarity.span
 
     def new_child_span(name, parent_scope=None):
+        log.debug(name)
         if parent_scope is None:
             parent_scope = compute_filter_similarity
         return compute_filter_similarity.tracer.start_active_span(name, child_of=parent_scope.span)
@@ -319,6 +320,8 @@ def compute_filter_similarity(package, project_id, run_id, threshold, encoding_s
             enc_dp2_size = len(enc_dp2)
             assert enc_dp1_size > 0, "Zero sized chunk in dp1"
             assert enc_dp2_size > 0, "Zero sized chunk in dp2"
+
+            log.debug("Calling anonlink with encodings", num_encodings_1=enc_dp1_size, num_encodings_2=enc_dp2_size)
             try:
                 sims, (rec_is0, rec_is1) = anonlink.similarities.dice_coefficient_accelerated(
                     datasets=(enc_dp1, enc_dp2),

--- a/backend/entityservice/tasks/encoding_uploading.py
+++ b/backend/entityservice/tasks/encoding_uploading.py
@@ -52,17 +52,16 @@ def pull_external_data(project_id, dp_id,
         mc = connect_to_object_store(env_credentials)
 
     log.debug("Pulling blocking information from object store")
+
     response = mc.get_object(bucket_name=blocks_object_info['bucket'], object_name=blocks_object_info['path'])
+    log.debug("Counting the blocks and hashing block names")
+    block_sizes = {}
     encoding_to_block_map = {}
     for k, v in ijson.kvitems(response.data, 'blocks'):
         log.warning(f"Encoding index: {k}, Blocks: {v}")
         # k is 0, v is ['3', '0']
-        encoding_to_block_map[str(k)] = list(map(hash_block_name, v))
-
-    log.debug("Counting the blocks")
-    block_sizes = {}
-    for encoding_id in encoding_to_block_map:
-        _blocks = encoding_to_block_map[encoding_id]
+        _blocks = list(map(hash_block_name, v))
+        encoding_to_block_map[str(k)] = _blocks
         for block_hash in _blocks:
             block_sizes[block_hash] = block_sizes.setdefault(block_hash, 0) + 1
 

--- a/backend/entityservice/tests/test_encoding_storage.py
+++ b/backend/entityservice/tests/test_encoding_storage.py
@@ -1,3 +1,5 @@
+import time
+
 from pathlib import Path
 import io
 
@@ -46,3 +48,12 @@ class TestEncodingStorage:
         assert len(encodings[0]) == 8
         assert hash_block_name(large_block_name) in blocks[0]
 
+    def test_hash_block_names_speed(self):
+        timeout = 10
+        input_strings = [str(i) for i in range(1_000_000)]
+        start_time = time.time()
+
+        for i, input_str in enumerate(input_strings):
+            hash_block_name(input_str)
+            if i % 10_000 == 0:
+                assert time.time() <= (start_time + timeout)

--- a/backend/entityservice/tests/test_encoding_storage.py
+++ b/backend/entityservice/tests/test_encoding_storage.py
@@ -3,7 +3,7 @@ import io
 
 import pytest
 
-from entityservice.encoding_storage import stream_json_clksnblocks
+from entityservice.encoding_storage import hash_block_name, stream_json_clksnblocks
 from entityservice.tests.util import serialize_bytes
 
 
@@ -13,10 +13,12 @@ class TestEncodingStorage:
         with open(filename, 'rb') as f:
             # stream_json_clksnblocks produces a generator of (entity_id, base64 encoding, list of blocks)
             encoding_ids, encodings, blocks = list(zip(*stream_json_clksnblocks(f)))
+
             assert len(encoding_ids) == 4
             assert len(encodings) == 4
-            assert len(blocks[0]) == 1
-            assert blocks[0][0] == '1'
+            first_blocks = list(blocks[0])
+            assert len(first_blocks) == 1
+            assert first_blocks[0] == hash_block_name('1')
 
     def test_convert_encodings_from_json_to_binary_empty(self):
         empty = io.BytesIO(b'''{
@@ -32,5 +34,15 @@ class TestEncodingStorage:
         encoding_ids, encodings, blocks = list(zip(*stream_json_clksnblocks(json_data)))
 
         assert len(encodings[0]) == 8
-        assert "02" in blocks[0]
+        assert hash_block_name("02") in blocks[0]
+
+    def test_convert_encodings_from_json_to_binary_large_block_name(self):
+        d = serialize_bytes(b'abcdabcd')
+        large_block_name = 'b10ck' * 64
+        json_data = io.BytesIO(b'{' + f'''"clknblocks": [["{d}", "{large_block_name}"]]'''.encode() + b'}')
+        encoding_ids, encodings, blocks = list(zip(*stream_json_clksnblocks(json_data)))
+
+        assert len(hash_block_name(large_block_name)) <= 64
+        assert len(encodings[0]) == 8
+        assert hash_block_name(large_block_name) in blocks[0]
 

--- a/e2etests/tests/test_results_correctness.py
+++ b/e2etests/tests/test_results_correctness.py
@@ -14,7 +14,7 @@ from e2etests.util import create_project_upload_data, post_run, get_run_result, 
 @pytest.fixture
 def the_truth(scope='module'):
     threshold = 0.8
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),'testdata/febrl4_clks_and_truth.pkl'), 'rb') as f:
+    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'testdata/febrl4_clks_and_truth.pkl'), 'rb') as f:
         # load prepared clks and ground truth from file
         filters_a, filters_b, entity_ids_a, entity_ids_b, clks_a, clks_b = pickle.load(f)
         # compute similarity scores with anonlink

--- a/e2etests/util.py
+++ b/e2etests/util.py
@@ -166,7 +166,7 @@ def create_project_upload_fake_data(
     data = generate_overlapping_clk_data(
         sizes, overlap=overlap, encoding_size=encoding_size)
     new_project_data, json_responses = create_project_upload_data(
-        requests, data, result_type=result_type)
+        requests, data, result_type=result_type, uses_blocking=uses_blocking)
     assert len(json_responses) == len(sizes)
     return new_project_data, json_responses
 
@@ -178,7 +178,7 @@ def create_project_upload_data(
 
     number_parties = len(data)
     new_project_data = create_project_no_data(
-        requests, result_type=result_type, number_parties=number_parties, uses_blocking=False)
+        requests, result_type=result_type, number_parties=number_parties, uses_blocking=uses_blocking)
 
     upload_url = url + f'/projects/{new_project_data["project_id"]}/{"binary" if binary else ""}clks'
     json_responses = []


### PR DESCRIPTION
Related to issue #632.

Block names were limited to 64 chars, for P-Sig we may very well want to use block ids that are based on bloom filters... a 64 char limit would impose a max bloom filter size of 512 bits (assuming a perfect encoding unlike json).

This small change increases the column size to 512 chars, although happy to increase further or remove the character limitation.