### PR TITLE
add total number of comparisons to completed status

### DIFF
--- a/backend/entityservice/views/run/status.py
+++ b/backend/entityservice/views/run/status.py
@@ -69,6 +69,7 @@ def get(project_id, run_id):
     if state == 'completed':
         status["time_started"] = run_status['time_started']
         status["time_completed"] = run_status['time_completed']
+        status["total_number_comparisons"] = progress_cache.get_total_number_of_comparisons(project_id)
         return completed().dump(status)
     elif state == 'running' or state == 'queued' or state == 'created':
         status["time_started"] = run_status['time_started']

--- a/backend/entityservice/views/serialization.py
+++ b/backend/entityservice/views/serialization.py
@@ -65,6 +65,7 @@ class RunStatus(Schema):
 class completed(RunStatus):
     time_started = fields.DateTime(format='iso8601', required=True)
     time_completed = fields.DateTime(format='iso8601', required=True)
+    total_number_comparisons = fields.Integer(required=True)
 
 
 class queued(RunStatus):


### PR DESCRIPTION
Once a run is complete, the status now reports the total number of comparisons.