### PR TITLE
Upgrade to native dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/base/"
+    # Check for updates to the base docker image once a week
+    schedule:
+      interval: "weekly"
+  # Enable version updates for Python Dependencies
+  - package-ecosystem: "pip"
+    directory: "/base/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Dependabot is now natively built into github, the old method is no longer working ([recent PR comment](https://github.com/data61/anonlink-entity-service/pull/657#issuecomment-902263047))

You can read more at:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/upgrading-from-dependabotcom-to-github-native-dependabot#upgrading-to-github-native-dependabot

This PR creates the new configuration for dependabot stored in the repo.