### PR TITLE
Remove manual string format from SQL query to delete data providers

### DIFF
--- a/backend/entityservice/database/deletion.py
+++ b/backend/entityservice/database/deletion.py
@@ -63,10 +63,12 @@ def delete_project_data(conn, project_id):
                 WHERE
                     permutation_masks.project =  %s
                 """, [project_id])
+
             log.debug("delete dataproviders with all associated encodings, blocks and upload data.")
             cur.execute("""
                 DELETE
                 FROM dataproviders
                 WHERE
-                    id in ({})""".format(','.join(map(str, dp_ids))))
+                    id = ANY(%s)""", (dp_ids,)
+            )
         log.debug("Committing removal of project resource")

--- a/benchmarking/default-experiments.json
+++ b/benchmarking/default-experiments.json
@@ -1,6 +1,6 @@
 [
   {
-    "sizes": ["100K", "100K"],
+    "sizes": ["10K", "10K"],
     "threshold": 0.95
   },
   {
@@ -20,10 +20,5 @@
     "sizes": ["100K", "1M"],
     "use_blocking": true,
     "threshold": 0.95
-  },
-  {
-    "sizes": ["1M", "1M"],
-    "use_blocking": true,
-    "threshold": 0.8
   }
 ]


### PR DESCRIPTION
According to the psycopg docs one should 

> Never, **never**, **NEVER** use Python string concatenation (+) or string parameters interpolation (%) to pass variables to a SQL query string. Not even at gunpoint.

Just replacing the string formatting with passing the dp_ids list arguments to the `execute` function doesn't work, but the docs suggest using the [`ANY`](https://www.psycopg.org/docs/usage.html#lists-adaptation) operator, which according to the [postgresql docs](https://www.postgresql.org/docs/current/functions-subquery.html#FUNCTIONS-SUBQUERY-ANY-SOME) is actually equivalent:

> `IN` is equivalent to `= ANY`

Which is news to me so thought I'd share.

Finally I removed a default entry from the benchmarks run by the CI as they were [occasionally failing](https://dev.azure.com/data61/Anonlink/_build?definitionId=1&_a=summary&branchFilter=1165%2C1165).