### PR TITLE
Make progress update more robust

### DIFF
--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -32,6 +32,7 @@ class Config(object):
     REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', '')
     REDIS_USE_SENTINEL = os.getenv('REDIS_USE_SENTINEL', 'false').lower() == "true"
     REDIS_SENTINEL_NAME = os.getenv('REDIS_SENTINEL_NAME', 'mymaster')
+    REDIS_SOCKET_TIMEOUT = float(os.getenv('REDIS_SOCKET_TIMEOUT', '5.0'))
 
     MINIO_SERVER = os.getenv('MINIO_SERVER', 'minio:9000')
     MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY', '')


### PR DESCRIPTION
Saving comparison progress in redis now uses a configurable timeout for connecting, and has a retry using tenacity

The redis updates are pipelined together so they either all succeed or all fail.