### PR TITLE
fixing jsonschema

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,3 +1,4 @@
+jsonschema==3.2.0
 alembic==1.6.5
 anonlink==0.14.2
 anonlink-client==0.1.5


### PR DESCRIPTION
the 4.x releases of jsonschema don't work with the current code base.
For now, we fix jsonschema to last know working version 3.2.0.