### PR TITLE
👷 Update base alpine version to v3.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,6 +272,43 @@ stages:
         inputs:
           helmVersionToInstall: 'latest'
 
+      # Show what is installed in the test namespace in-case a cleanup has failed
+      - task: Kubernetes@1
+        displayName: 'List Installed Deployments'
+        name: listdeployments
+        inputs:
+          connectionType: 'Kubernetes Service Connection'
+          kubernetesServiceEndpoint: $(CLUSTER)
+          command: 'get'
+          arguments: '--namespace $(NAMESPACE) deployment'
+
+      - task: Kubernetes@1
+        displayName: 'List Installed Jobs'
+        name: listjobs
+        inputs:
+          connectionType: 'Kubernetes Service Connection'
+          kubernetesServiceEndpoint: $(CLUSTER)
+          command: 'get'
+          arguments: '--namespace $(NAMESPACE) jobs'
+
+      - task: Kubernetes@1
+        displayName: 'List Installed Volumes'
+        name: listvols
+        inputs:
+          connectionType: 'Kubernetes Service Connection'
+          kubernetesServiceEndpoint: $(CLUSTER)
+          command: 'get'
+          arguments: '--namespace $(NAMESPACE) pvc,pv'
+
+      - task: Kubernetes@1
+        displayName: 'List Installed statefulsets'
+        name: liststatefulsets
+        inputs:
+          connectionType: 'Kubernetes Service Connection'
+          kubernetesServiceEndpoint: $(CLUSTER)
+          command: 'get'
+          arguments: '--namespace $(NAMESPACE) statefulsets'
+
       - task: HelmDeploy@0
         displayName: Helm package
         inputs:

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,12 +1,10 @@
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# Search for current versions at
-# https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.13&arch=x86_64
 # postgresql-dev needed for pg_config
 # c compiler, python-dev, libpq, libpq-dev needed by psycopg2 (https://www.psycopg.org/docs/install.html)
 # libffi-dev needed by anonlink
@@ -17,24 +15,24 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 WORKDIR /var/www
 ADD requirements.txt /var/www/requirements.txt
 RUN apk add --no-cache \
-    python3=3.9.5-r1 \
-    py3-pip=20.3.4-r1 \
-    libstdc++=10.3.1_git20210424-r2 \
-    mpc1-dev=1.2.1-r0 \
-    yajl=2.1.0-r1 \
-    libpq=13.4-r0 \
-    openssl-dev=1.1.1l-r0 \
-    cargo=1.52.1-r1 && \
+    python3 \
+    py3-pip\
+    libstdc++ \
+    mpc1-dev \
+    yajl \
+    libpq \
+    openssl-dev \
+    cargo && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     apk add --no-cache --virtual .build-deps \
-    g++=10.3.1_git20210424-r2 \
-    python3-dev=3.9.5-r1 \
-    yajl-dev=2.1.0-r1 \
-    postgresql-dev=13.4-r0 \
-    libffi-dev=3.3-r2 \
-    gmp-dev=6.2.1-r0 \
-    mpfr-dev=4.1.0-r0 \
-    wait4ports=0.3.3-r0 \
+    g++ \
+    python3-dev \
+    yajl-dev \
+    postgresql-dev \
+    libffi-dev \
+    gmp-dev \
+    mpfr-dev \
+    wait4ports \
     git && \
     pip install setuptools wheel && \
     python -m pip install --upgrade pip && \

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema==3.2.0
-alembic==1.6.5
+alembic==1.7.5
 anonlink==0.14.2
 anonlink-client==0.1.5
 bitarray-hardbyte==1.6.2
@@ -15,7 +15,7 @@ ijson==3.1.4
 iso8601==0.1.16
 jaeger-client==4.8.0
 marshmallow==3.13.0
-minio==7.1.0
+minio==7.1.1
 opentracing==2.4.0
 opentracing_instrumentation==3.3.1
 psycopg2==2.9.1


### PR DESCRIPTION
I noted that building the base image wasn't actually reproducible despite our overzealous pinning of requirements... so to make life easier I suggest we continue to pin the FROM docker image but allow alpine to find the consistent set of packages within that.

I've manually built and ran e2e tests via docker-compose.